### PR TITLE
Bedre håndtering af \todo

### DIFF
--- a/GithubToSlack.php
+++ b/GithubToSlack.php
@@ -50,10 +50,10 @@ if($string !== NULL){
 				$lines = explode("\n", $file['patch']);
 				foreach($lines as $line){
 					$line = str_replace("\\", "\\\\", $line);
-					$line = remove_todos($line);
-					if(str_split($line)[0] === '+'){
-						if(preg_match('/[\s+][mM]an[\W]/', $line)  === 1){
-							$man_lines[] = $line;
+					$filtered_line = remove_todos($line);
+					if(str_split($filtered_line)[0] === '+'){
+						if(preg_match('/[\s+][mM]an[\W]/', $filtered_line)  === 1){
+							$man_lines[] = $filtered_line;
 							echo $line;
 						}
 						/*if(preg_match('/[\s+][Vv]i\W/', $line)  === 1){
@@ -135,6 +135,10 @@ function remove_todos($line) {
             echo(sprintf("charat pos %d == %s", $pos, char_at($line, $pos)));
             $pos++;
             //$stack->pop();
+        }
+        //Skip to opening brace
+        while (char_at($line, $pos) !== "{") {
+            $pos++;
         }
         $stack->push(mb_substr($line, $pos, $pos+1));
         while (!$stack->isEmpty()) {

--- a/GithubToSlack.php
+++ b/GithubToSlack.php
@@ -131,22 +131,23 @@ function remove_todos($line) {
             while (char_at($line, $pos) !== "]") {
                 $pos++;
             }
-            if ($stack->top() !== char_at($line, $pos)) {
-                trigger_error("Parenthesis mismatch");
-            }
-            $stack->pop();
+            echo(sprintf("charat pos %d == %s", $pos, char_at($line, $pos)));
+            $pos++;
+            //$stack->pop();
         }
-        $stack[] = mb_substr($line, $pos, $pos+1);
+        $stack->push(mb_substr($line, $pos, $pos+1));
         while (!$stack->isEmpty()) {
             $pos++;
-            if (strpos($startparens, char_at($line, $pos)) !== false) {
-                $stack[] = char_at($line, $pos);
+            if (char_at($line, $pos) === "{") {
+                $stack->push(char_at($line, $pos));
             }
-            elseif (strpos($endparens, char_at($line, $pos)) !== false) {
+            elseif (char_at($line, $pos) === "}") {
                 $stack->pop();
             }
         }
+        echo(sprintf("Substring \"%s\" at pos %d to %d\n", $line, $startpos, $pos));
         $line = str_replace(mb_substr($line, $startpos, $pos - $startpos + 1), "", $line);
+        echo(sprintf("After removal: %s\n", $line));
         $pos = strpos($line, "\\todo");
     }
     return $line;

--- a/GithubToSlack.php
+++ b/GithubToSlack.php
@@ -49,6 +49,7 @@ if($string !== NULL){
 			foreach($commit_info['files'] as $file){
 				$lines = explode("\n", $file['patch']);
 				foreach($lines as $line){
+					$line = str_replace("\\", "\\\\", $line);
 					$line = remove_todos($line);
 					if(str_split($line)[0] === '+'){
 						if(preg_match('/[\s+][mM]an[\W]/', $line)  === 1){


### PR DESCRIPTION
Manhunteren skulle nu gerne håndtere `\todo` fornuftigt ift. ikke at manhunte todos. Desuden escapes alle backslashes nu. 