### PR TITLE
Fix unicode-related bug

### DIFF
--- a/GithubToSlack.php
+++ b/GithubToSlack.php
@@ -114,46 +114,37 @@ function char_at($str, $pos) {
 }
 
 function remove_todos($line) {
-    $len = strlen($line);
-    $pos = strpos($line, "\\todo");
+    $len = mb_strlen($line);
+    $pos = mb_strpos($line, "\\todo");
     $stack = new SplStack();
-    $startparens = "([{";
-    $endparens = ")]}";
-    while (strpos($line, "\\todo") !== false && $pos < $len) {
-        echo($line);
+    while ($pos < $len && $pos !== false  ) {
+        echo($line."\n");
         echo(sprintf("pos == %s\n", $pos));
         $startpos = $pos;
-        /* Skip to first parenthesis */
-        while (strpos($startparens, char_at($line, $pos)) === false) {
-            $pos++;
-        }
-        /* Skip optional parameters */
-        if (char_at($line, $pos) == "[") {
-            while (char_at($line, $pos) !== "]") {
-                $pos++;
-            }
-            echo(sprintf("charat pos %d == %s", $pos, char_at($line, $pos)));
-            $pos++;
-            //$stack->pop();
-        }
+        echo("Character at pos: ".char_at($line,$pos)."\n");
+        echo("Startpos = ".$startpos."\n");
         //Skip to opening brace
         while (char_at($line, $pos) !== "{") {
             $pos++;
         }
-        $stack->push(mb_substr($line, $pos, $pos+1));
+        //Use stack to track opened braces.
+        $stack->push(char_at($line, $pos));
+        //Stack should be empty on closing brace.
         while (!$stack->isEmpty()) {
             $pos++;
             if (char_at($line, $pos) === "{") {
                 $stack->push(char_at($line, $pos));
             }
-            elseif (char_at($line, $pos) === "}") {
+			elseif (char_at($line, $pos) === "}") {
                 $stack->pop();
             }
         }
         echo(sprintf("Substring \"%s\" at pos %d to %d\n", $line, $startpos, $pos));
+        //Remove contents
         $line = str_replace(mb_substr($line, $startpos, $pos - $startpos + 1), "", $line);
         echo(sprintf("After removal: %s\n", $line));
-        $pos = strpos($line, "\\todo");
+        //Setup for next iteration
+        $pos = mb_strpos($line, "\\todo");
     }
     return $line;
 }

--- a/testEnviron/.gitignore
+++ b/testEnviron/.gitignore
@@ -1,0 +1,49 @@
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties

--- a/testEnviron/src/TextTest.php
+++ b/testEnviron/src/TextTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: waefwerf
+ * Date: 3/8/18
+ * Time: 12:19 PM
+ */
+
+use PHPUnit\Framework\TestCase;
+
+include "texthandling.php";
+
+class TextTest extends TestCase
+{
+    function testNoTodos()
+    {
+        $inputstr = "Hello world";
+        $this->assertTrue($inputstr === remove_todos($inputstr));
+    }
+
+    function testRemoveSingleTodo()
+    {
+        $inputstr = "Hello \\todo{goodbye}";
+        $res = remove_todos($inputstr);
+        $this->assertTrue(remove_todos($inputstr) === "Hello ");
+    }
+
+    function testHandlesNestedBraces()
+    {
+        $inputstr = "This is nested\\todo{{hello}}";
+        $res = remove_todos($inputstr);
+        $this->assertTrue($res == "This is nested");
+    }
+
+    function testHandlesMultipleTodos()
+    {
+        $inputstr = "Hi\\todo{hello} there\\todo{lel}";
+        $res = remove_todos($inputstr);
+        $this->assertTrue($res === "Hi there");
+    }
+
+    function testHandlesOptArgs()
+    {
+        $inputstr = "Optional \\todo[asd]{adadsdaw}";
+        $res = remove_todos($inputstr);
+        $this->assertTrue($res === "Optional ");
+    }
+
+    function testSpaceBeforeBrace()
+    {
+        $inputstr = "Optional \\todo[asd] {adadsdaw}";
+        $res = remove_todos($inputstr);
+        $this->assertTrue($res === "Optional ");
+    }
+
+    function testSpaceBeforeOptArgs()
+    {
+        $inputstr = "Optional \\todo [asd]{adadsdaw}";
+        $res = remove_todos($inputstr);
+        $this->assertTrue($res === "Optional ");
+    }
+
+    function testTextAfterTodo()
+    {
+        $inputstr = "\\todo{asdlkajd} der skal være tekst her.";
+        $res = remove_todos($inputstr);
+        $this->assertTrue($res === " der skal være tekst her.");
+    }
+
+    function testEmptyString()
+    {
+        $inputstr = "";
+        $res = remove_todos($inputstr);
+        $this->assertTrue($res === "");
+        $inputstr = '';
+        $res = remove_todos($inputstr);
+        $this->assertTrue($res === '');
+    }
+    function testEmptyStringPlus()
+    {
+        $inputstr = "+";
+        $res = remove_todos($inputstr);
+        $this->assertTrue($res === "+");
+    }
+    function testManhunt_NoMans()
+    {
+        $inputstr = "Der er intet galt her";
+        echo manhunt($inputstr);
+        $this->assertTrue(manhunt($inputstr) === false);
+    }
+
+    function testManhunt_CapitalMan()
+    {
+        $inputstr = "+ Man burde teste";
+        $this->assertTrue(manhunt($inputstr) !== false);
+    }
+
+    function testManhunt_lowercaseMan()
+    {
+        $inputstr = "+ Hvis man ser her";
+        $this->assertTrue(manhunt($inputstr) !== false);
+    }
+
+    function testManhunt_doesntRemoveTodos()
+    {
+        $inputstr = "+ Man burde teste det her\todo{asd}";
+        echo($inputstr);
+        $this->assertTrue(manhunt($inputstr) === "+ Man burde teste det her\\todo{asd}");
+    }
+    function testManhuntRealInput()
+    {
+        $inputstr = "\renewcommand{\\thepage}{\alphalph{\value{page}}}";
+        $this->assertTrue(manhunt($inputstr) === false);
+        $inputstr = "		\includegraphics[width=\linewidth]{figures/dotexample.pdf}\n";
+        $this->assertTrue(manhunt($inputstr) === false);
+    }
+    function testRemovesTodosInComments()
+    {
+        $inputstr = "%\\todo[inline]{Syntes der bliver brugt for lidt energi på biblioteket. Hvorfor er der ikke et kodeeksempel på dette, og hvilke fordele/ulemper er der ved det? Hvis Java eller CS fikser de nævnte problemer, hvorfor er de så ikke overvejet nærmere?}";
+        $this->assertTrue(remove_todos($inputstr) == "%");
+    }
+    function testDumbLine()
+    {
+        $inputstr = '+%Sidst er sproget meget specifikt, så det kræver en grafisk brugergrænseflade, og det er svært at generalisere algoritmer\todo{Citation needed}, hvoraf sidstnævnte vil være en fordel ved f.eks. Dijkstras algoritme, jf. afsnit \ref{sec:problemanalyse_graphproblems_shortestpath}\todo{Ref til Dijkstra afsnit når merged}, hvor vægten på en kant kan opfattes som en variabel på hver kant eller en funktion for vægten mellem to knuder.';
+        $expect = '+%Sidst er sproget meget specifikt, så det kræver en grafisk brugergrænseflade, og det er svært at generalisere algoritmer, hvoraf sidstnævnte vil være en fordel ved f.eks. Dijkstras algoritme, jf. afsnit \ref{sec:problemanalyse_graphproblems_shortestpath}, hvor vægten på en kant kan opfattes som en variabel på hver kant eller en funktion for vægten mellem to knuder.';
+        $this->assertTrue(remove_todos($inputstr) === $expect);
+    }
+    function testManhuntGitDiff()
+    {
+        $inputstr = file_get_contents("gitdiff", FILE_USE_INCLUDE_PATH);
+        $lines = explode("\n", $inputstr);
+        for ($i = 1136; $i < count($lines); ++$i) {
+            echo(sprintf("Lines: %s\tLength: %d\n", $i+1, strlen($lines[$i])));
+            manhunt($lines[$i]);
+        }
+        $this->assertTrue(true);
+    }
+}
+
+

--- a/testEnviron/src/gitdiff
+++ b/testEnviron/src/gitdiff
@@ -1,0 +1,6585 @@
+diff --git a/Rapport/bib/mybib.bib b/Rapport/bib/mybib.bib
+index 2f0c966..c79c406 100644
+--- a/Rapport/bib/mybib.bib
++++ b/Rapport/bib/mybib.bib
+@@ -12,6 +12,14 @@
+   howpublished = {\url{http://tobi.oetiker.ch/lshort/lshort.pdf}}
+  }
+  
++@Article{North2014, 
++	author = {Stephen C. North and Emden R. Gansner},
++	title = {Cgraph Tutorial},
++	year = {2014},
++	url = {https://graphviz.gitlab.io/_pages/pdf/cgraph.pdf},
++	urldate = {2018-03-06},
++}
++ 
+ @BOOK{Mittelbach2005,
+   author = {Frank Mittelbach},
+   edition = {2. ed.},
+@@ -49,6 +57,26 @@
+ 	edition = {Eleventh edition},
+ 	isbn = {978-1-292-10055-5},
+ }
++
++@BOOK{Rosen2013,
++	author = {Kenneth H. Rosen},
++	title = {Discrete Mathematics and Its Applications},
++	year = {2013},
++	publisher = {McGraw-Hill Education},
++	edition = {Global edition},
++	isbn = {978-9-81467013-5},
++}
++
++@ARTICLE{Gansner00,
++    author = {Emden R. Gansner and Stephen C. North},
++    title = {An open graph visualization system and its applications to software engineering},
++    journal = {SOFTWARE - PRACTICE AND EXPERIENCE},
++    year = {2000},
++    volume = {30},
++    number = {11},
++    pages = {1203--1233}
++}
++
+ @BOOK{Sipser2013,
+ 	author = {Michael Sipser},
+ 	title = {Introduction to the Theory of Computation},
+@@ -56,6 +84,31 @@
+ 	isbn = {978-1-133-18781-3},
+ 	edition = {3rd edition},
+ }
++@Misc{LanguageBenchmark,
++  title = {Language Benchmark},
++  year  = {2017},
++  url   = {http://www.bioinformatics.org/benchmark/results.html},
++  urldate   = {2018-02-20},
++}
++@Misc{Plump2009,
++	title   = {The Graph Programming Language GP},
++	year	= {2009},
++	url     = {https://www.cs.york.ac.uk/plasma/publications/pdf/Plump.CAI.09.pdf},
++  	urldate = {2018-02-22},
++}
++@Misc{GP2Issues,
++  title   = {Using 'and' inside 'not' in a Rule Condition causes a build error},
++  year  = {2017},
++  url     = {https://github.com/UoYCS-plasma/GP2/issues/10},
++    urldate = {2018-02-22},
++}
++@Misc{DOTGraphs,
++  title = {Drawing graphs with dot},
++  year  = {2015},
++  url   = {http://www.graphviz.org/pdf/dotguide.pdf},
++  urldate   = {2018-03-02},
++}
++
+ @BOOK{Hart2003,
+ 	author = {Chad Hart},
+ 	title = {Graph Theory Topics in Computer Networking},
+@@ -63,7 +116,7 @@
+ 	howpublished = {\url{http://cms.uhd.edu/faculty/redlt/chadseniorproject.pdf}}
+ }
+ @BOOK{Chartrand2016,
+-	author = {{Chartrand, Lesniak \& Zhang}}},
++	author = {{Chartrand, Lesniak \& Zhang}},
+ 	title = {Graphs \& Digraphs},
+ 	year = {2013},
+ 	edition = {6th edition},
+diff --git a/Rapport/figures/dotexample.pdf b/Rapport/figures/dotexample.pdf
+new file mode 100644
+index 0000000..1a552b6
+Binary files /dev/null and b/Rapport/figures/dotexample.pdf differ
+diff --git a/Rapport/figures/tables/lexemes.tex b/Rapport/figures/tables/lexemes.tex
+new file mode 100644
+index 0000000..8301922
+--- /dev/null
++++ b/Rapport/figures/tables/lexemes.tex
+@@ -0,0 +1,12 @@
++	\begin{tabular}{ll}
++		\toprule
++		Token & Regulært udtryk \\
++		\midrule
++		IntLiteral & \texttt{(+|-)?[0-9]+}\\
++		FloatLiteral & \texttt{(+|-)?[0-9]+\textbackslash{}.[0-9]+}\\
++		CharLiteral & \texttt{`(\textbackslash{}\textbackslash{}(`$\vert$\textbackslash{}\textbackslash{})$\vert{}$[\^{}'\textbackslash{}\textbackslash{}])'}\\
++		StringLiteral & \texttt{\textbackslash{}\textquotedblleft{}(\textbackslash{}\textbackslash{}(n|{}t|{}\textbackslash{}\textbackslash{})|[\^{}\textbackslash{}\textquotedblright{}\textbackslash{}\textbackslash{}\textbackslash{}n])*\textbackslash{}\textquotedblright{}}\\
++		BoolLiteral & \texttt{true} | \texttt{false}\\
++		Id & \texttt{[a-zA-Z\_][a-zA-Z0-9\_]*}\\
++		\bottomrule
++	\end{tabular}
+\ No newline at end of file
+diff --git a/Rapport/listings/cgraf.c b/Rapport/listings/cgraf.c
+new file mode 100644
+index 0000000..b025ac0
+--- /dev/null
++++ b/Rapport/listings/cgraf.c
+@@ -0,0 +1,52 @@
++#include <stdlib.h>
++
++#define EDGE_IN_GRAPH 1
++#define VERTEX_OUT_OF_RANGE -1
++
++//Doubly linked list
++struct node_t { 
++    int val;
++    struct node_t* next;
++    struct node_t* prev;
++} node;
++
++typedef struct {
++    int num_vertices;
++    struct node_t *adj[];
++} graph_t;
++
++int add_edge(graph_t *graph, int start, int end);
++struct node_t *create_node(struct node_t *prev, int val, struct node_t *next);
++
++int add_edge(graph_t *graph, int start, int end) 
++{
++    if (start > graph->num_vertices) {
++        return VERTEX_OUT_OF_RANGE; //Error code: start is not a vertex in graph
++    }
++    struct node_t *node = graph->adj[start];
++    //Skip to end of adjacency list
++    while (node->next != NULL) {
++        if (node->val == end) {
++            return EDGE_IN_GRAPH; //Edge already in graph
++        }
++        node = node->next;
++    }
++    struct node_t *next = create_node(node, end, NULL);
++    node->next = next;
++    return 0; //Success
++}
++
++struct node_t *create_node(struct node_t *prev, int val, struct node_t *next) 
++{
++    struct node_t *node = (struct node_t*) malloc(sizeof(struct node_t));
++    node->prev = prev;
++    node->next = next;
++    node->val  = val;
++    return node;
++}
++
++
++int main(int argc, char *argv[]) 
++{
++    return 0;
++}
+\ No newline at end of file
+diff --git a/Rapport/listings/knud/blockillegal.tex b/Rapport/listings/knud/blockillegal.tex
+new file mode 100644
+index 0000000..b87a2e8
+--- /dev/null
++++ b/Rapport/listings/knud/blockillegal.tex
+@@ -0,0 +1,7 @@
++//Ulovlig
++if (expr) 
++	//...
++else if (expr)
++	//...
++else
++	//... 
+\ No newline at end of file
+diff --git a/Rapport/listings/knud/blocklegal.tex b/Rapport/listings/knud/blocklegal.tex
+new file mode 100644
+index 0000000..7ab184d
+--- /dev/null
++++ b/Rapport/listings/knud/blocklegal.tex
+@@ -0,0 +1,7 @@
++//Lovlig
++if (expr) {
++	//...
++}
++else if {
++	//...
++}
+\ No newline at end of file
+diff --git a/Rapport/listings/knud/graphattributeaddition.tex b/Rapport/listings/knud/graphattributeaddition.tex
+new file mode 100644
+index 0000000..e725306
+--- /dev/null
++++ b/Rapport/listings/knud/graphattributeaddition.tex
+@@ -0,0 +1,11 @@
++void foo(graph G) {
++	//Erklæring af nye attributter på G
++	define(G) {
++		vertex int a;
++		vertex int b = 0;
++	}
++	// ...
++	for (vertex v in V(G)) {¤\label{lstline:specifikation_cfg_forloopeksempel}¤
++		v.a = 0;¤\label{lstline:specifikation_cfg_grafattributeksempel_assign}¤
++	}
++}
+\ No newline at end of file
+diff --git a/Rapport/listings/knud/graphdclexample.tex b/Rapport/listings/knud/graphdclexample.tex
+new file mode 100644
+index 0000000..7a8f660
+--- /dev/null
++++ b/Rapport/listings/knud/graphdclexample.tex
+@@ -0,0 +1,9 @@
++graph G = graph {
++	vertex int a;¤\label{lstline:specifikation_cfg_grafeksempel_attrdclstart}¤
++	vertex int b = 0; //Standard-værdi
++	edge float c;¤\label{lstline:specifikation_cfg_grafeksempel_attrdclend}¤
++	//Alle kanter får c = 0.5
++	A -- B -- C [c = 0.5];
++	//Kanterne får c = hhv. 0.3, 0.5, 0.8. 
++	D -- E -- F -- G [c = {0.3, 0.5, 0.8}];
++} 
+diff --git a/Rapport/listings/knud/invariant.tex b/Rapport/listings/knud/invariant.tex
+new file mode 100644
+index 0000000..8ab322c
+--- /dev/null
++++ b/Rapport/listings/knud/invariant.tex
+@@ -0,0 +1,3 @@
++graph G;
++// ...
++for (vertex v in V(G)) invariant()
+\ No newline at end of file
+diff --git a/Rapport/listings/kode_eksempler/BFS.tex b/Rapport/listings/kode_eksempler/BFS.tex
+new file mode 100644
+index 0000000..79482c1
+--- /dev/null
++++ b/Rapport/listings/kode_eksempler/BFS.tex
+@@ -0,0 +1,48 @@
++\begin{lstlisting}[caption={\texttt{BFS kode eksempler}.},escapechar=¤]
++digraph G = digraph {
++// DOT-like syntaks: Tre implicit erklærede knuder, kanter mellem dem (grafen er en 3-cykel) og specificerede kantvægte.
++  edge float weight = 0;
++  q1 -> q2 -> q3 -> q1 [weight = {0.5, 0.3, 0.4}];
++}
++
++digraph BFS(graph G, vertex s, int k)
++  // Definerer attributter for grafen
++  define(G) {
++    //Attribut på knuder med optional default-værdi
++    vertex int d = int_max;
++    vertex Color color = white;
++    vertex vertex parent = null;
++  }
++{
++  assert s in V(G);
++
++  // En kø og en linked list er bare orienterede grafer  
++  digraph Q = CreateEmptyQueue();
++  digraph dest = CreateEmptyList();
++
++  s.color = gray;
++  s.d = 0;
++  Enqueue(Q, s);
++
++  //|Q| Kardinaliteten af knudemængden
++  while(|Q| > 0)
++  {
++    vertex u = Dequeue(Q);
++    if(u.d <= k) { 
++      InsertToList(dest, u); 
++    }
++
++    // G.Adj[u] er nabomængden for u i G
++    for (vertex v in G.Adj[u]) { 
++      if (v.color == white) { 
++        v.color = gray;
++        v.d = u.d + 1;
++        v.parent = u;
++        Enqueue(Q,v);
++      }
++    }
++    u.color = black;
++  }
++  return dest;
++}
++\end{lstlisting}
+diff --git a/Rapport/listings/kode_eksempler/Euler.tex b/Rapport/listings/kode_eksempler/Euler.tex
+new file mode 100644
+index 0000000..5ed35b4
+--- /dev/null
++++ b/Rapport/listings/kode_eksempler/Euler.tex
+@@ -0,0 +1,156 @@
++\begin{lstlisting}[caption={\texttt{Euler kode eksempler}.},escapechar=¤]
++// Denne graf repræsenterer kantmængden {(q1, q2), (q2,q3), (q3,q4), (q4,q6), (q1,q3), (q3,q5), (q5,q6)}.
++graph G = graph {
++  q1 -- q2 -- q3 -- q4 -- q6;
++  q1 -- q3 -- q5 -- q6;
++}
++
++// Her checker vi om man kan lave en euler kreds i den givne graf.
++digraph EulerCircuit(graph G)
++{
++  digraph list = CreateEmptyList();
++
++  if(not StronglyConnectedComponent(G)) {
++    return list;
++  }
++  // Knudemængden i G
++  for (vertex v in V(G)) {
++    // |G.Adj[v] er størrelsen af nabolisten til v
++    if (|G.Adj[v]| % 2 != 0) {
++      return list;
++    }
++  }
++
++  // Her laves en deep copy af G
++  graph Copy = val G;
++  vertex start = RandomElement(V(G));
++  digraph bridges = Bridges(Copy);
++
++  vertex cur = start;
++  InsertToList(list, start);
++    
++  // ||Copy|| = Antal kanter i grafen
++  while(||Copy|| > 0) 
++  {
++    edge target = First(Copy.AdjEdge[cur]);
++    for (edge e in Copy.AdjEdge[cur])
++    {
++      if(!IsBridge(e)){
++        target = e;
++      }
++    }
++
++    // Kant, target, går fra cur til x, hvor Opposite returner x
++    cur = Opposite(target, cur);
++    InsertToList(list, cur);
++    Copy = Copy - target;
++  }
++}
++
++// Hjælpefunktion til at finde ud af om en kant er en bridge
++bool IsBridge(Graph G, edge e)
++{
++  digraph bridges = Bridges(G);
++  for (edge g in E(bridges))
++  {
++    if(g == e) {
++      return true;
++    }
++  }
++  return false;
++}
++
++bool StronglyConnectedComponent(graph G) 
++  define(G) {
++    vertex int index = int_max;
++    vertex int lowlink = int_max;
++    vertex bool onStack = false;
++  }
++{
++  int index = 0;
++  graph stack = CreateEmptyStack();
++  graph finalStack = CreateEmptyStack();
++
++  for (vertex v in V(G))
++  {
++    if(v.index == int_max) {
++      index = StrongConnect(G, v, stack, finalStack, index);
++    }
++  }
++    
++  return V(G) == V(finalStack);
++}
++
++int StrongConnect(graph G, vertex v, digraph S, digraph F, int index) {
++  v.index = index;
++  v.lowlink = index;
++  index++;
++  PushOnStack(S, v);
++  v.onStack = true;
++
++  for (edge e in E(G))
++  {
++    vertex w = Opposite(G, v);
++    if(w.index == int_max) {
++      index = StrongConnect(G, w, S, F, index);
++    }
++    else if(w.onStack) {
++      v.lowlink = min(v.lowlink, w.index);
++    }
++  }
++
++  if (v.lowlink == v.index) {  
++    do {
++      vertex w = PopFromStack(S); 
++      w.onStack = false;
++      PushOnStack(F, w);
++    } while(w != v);
++  } 
++
++  return index;
++}
++
++digraph Bridges(graph G)
++{
++  digraph bridges = CreateEmptyList();
++  for (edge e in E(G)) 
++  {
++    G = G - e;
++    IsBridge = BFSReachable(G, Source(e), Dest(e));
++    if(IsBridge) {
++      InsertToList(bridges, e);
++    }
++    G = G + e;
++  }
++
++  return bridges;
++}
++
++bool BFSReachable(graph G, vertex s, vertex fini)
++  define(G) {
++    vertex bool visited = false;
++  }
++{
++  assert s in V(G), ''s must be contained in G'';
++  assert fini in V(G), ''fini must be contained in G'';
++  
++  digraph Q = CreateEmptyQueue();
++
++  s.visited = true;
++  Enqueue(Q, s);
++
++  while(|Q| > 0) //|Q| Kardinaliteten af knudemængden
++  {
++    vertex u = Dequeue(Q);
++
++    // G.Adj[u] er nabomængden for u i G
++    for (vertex v in G.Adj[u]) { 
++      if (not v.visited) { 
++        v.visited = true;
++        Enqueue(Q,v);
++      }
++    }
++  }
++  return not fini.visited;
++}
++\end{lstlisting}
+\ No newline at end of file
+diff --git a/Rapport/listings/kode_eksempler/graf_i_c.tex b/Rapport/listings/kode_eksempler/graf_i_c.tex
+new file mode 100644
+index 0000000..bd04f9a
+--- /dev/null
++++ b/Rapport/listings/kode_eksempler/graf_i_c.tex
+@@ -0,0 +1,45 @@
++\begin{lstlisting}[caption={\texttt{Grafer i C}.},escapechar=¤]
++#include <stdlib.h>
++#define EDGE_IN_GRAPH 1
++#define VERTEX_OUT_OF_RANGE -1
++
++//Doubly linked list
++struct node_t { 
++	int val;
++	struct node_t* next;
++	struct node_t* prev;
++} node;
++typedef struct {
++	int num_vertices;
++	struct node_t *adj[];
++} graph_t;
++
++int add_edge(graph_t *graph, int start, int end);
++struct node_t *create_node(struct node_t *prev, int val, struct node_t *next);
++
++int add_edge(graph_t *graph, int start, int end) 
++{
++	if (start > graph->num_vertices)
++		return VERTEX_OUT_OF_RANGE; //Error code: start is not a vertex in graph
++	
++	struct node_t *node = graph->adj[start];
++	//Skip to end of adjacency list
++	while (node->next != NULL) {
++		if (node->val == end)
++			return EDGE_IN_GRAPH; //Edge already in graph
++		node = node->next;
++	}
++	struct node_t *next = create_node(node, end, NULL);
++	node->next = next;
++	return 0; //Success
++}
++
++struct node_t *create_node(struct node_t *prev, int val, struct node_t *next) 
++{
++	struct node_t *node = (struct node_t*) malloc(sizeof(struct node_t));
++	node->prev = prev;
++	node->next = next;
++	node->val  = val;
++	return node;
++}
++\end{lstlisting}
+\ No newline at end of file
+diff --git a/Rapport/master.tex b/Rapport/master.tex
+index f2d5c0a..79b7c51 100755
+--- a/Rapport/master.tex
++++ b/Rapport/master.tex
+@@ -22,6 +22,7 @@
+ \includeonly{%
+ 	sections/introduktion,%
+ 	sections/problemanalyse,%
++	sections/problemanalyse/criteria,%
+ 	sections/specifikation,%
+ 	sections/implementering,%
+ 	sections/diskussion,%
+@@ -48,13 +49,17 @@
+ \pagenumbering{arabic} %use arabic page numbering in the mainmatter
+ \include{sections/introduktion}
+ \include{sections/problemanalyse}
++\include{sections/problemanalyse/criteria}
+ \include{sections/specifikation}
+ \include{sections/implementering}
+ \include{sections/diskussion}
+ \include{sections/konklusion}
++
++
+ \label{pg:lastpage}
+ \printbibliography[heading=bibintoc]
+ \label{bib:mybiblio}
+ \appendix
+ \input{sections/appAname.tex}
++\input{sections/appMoscow.tex}
+ \end{document}
+diff --git a/Rapport/sections/appAname.tex b/Rapport/sections/appAname.tex
+index d98f460..533e91d 100755
+--- a/Rapport/sections/appAname.tex
++++ b/Rapport/sections/appAname.tex
+@@ -1,2 +1,42 @@
+-\chapter{Appendix A name}\label{ch:appAlabel}
+-Here is the first appendix
++\appendix
++\appendixpage
++\pagenumbering{arabic}
++\renewcommand{\thepage}{\alphalph{\value{page}}}
++\addappheadtotoc
++%---------Insert appendixes here---------------
++\chapter{Grafer i C}\label{app:graf-i-C}
++\input{listings/kode_eksempler/graf_i_c.tex}
++
++\chapter{Kontekst fri grammatik i Backus-Naur formalitet}
++\input{sections/appendix/bnf.tex}\label{app:bnf}
++
++\chapter{Kode eksempler: BFS}
++\input{listings/kode_eksempler/BFS.tex}
++
++\chapter{Kode eksempler: Euler}
++\input{listings/kode_eksempler/Euler.tex}
++
++\chapter{DOT kode eksempel} \label{app:DOT}
++\begin{figure}[h]
++	\begin{minipage}[b]{0.5\textwidth}
++		\begin{lstlisting}
++		digraph G {
++		A -> B -> C [color = red, style = dotted];
++		A -> D [color=blue];
++		D -> A;
++		A -> E;
++		}
++		\end{lstlisting}
++		\subcaption{Simpelt eksempel på DOT kode.}
++		\label{fig:problemanalyse_stateoftheart_dot_dotinput}
++		
++	\end{minipage}
++	\hfill
++	\begin{minipage}[b]{0.5\textwidth}
++		\includegraphics[width=\linewidth]{figures/dotexample.pdf}
++		\subcaption{Outputtet af \texttt{dot}.}
++		\label{fig:problemanalyse_stateoftheart_dot_dotoutput}
++	\end{minipage}
++	\caption{Eksempel på DOT kode og korresponderende output.}
++\end{figure}
++
+diff --git a/Rapport/sections/appMoscow.tex b/Rapport/sections/appMoscow.tex
+new file mode 100644
+index 0000000..c033b77
+--- /dev/null
++++ b/Rapport/sections/appMoscow.tex
+@@ -0,0 +1,110 @@
++\chapter{Funktionelle krav}\label{app:MoSCoW}
++\section{Must have}
++\begin{itemize}
++	\item Aritmetik
++	\item Assignment
++	\begin{itemize}
++		\item Reference-assignment
++		\item Deep-copy
++	\end{itemize}
++	\item Funktioner
++	\begin{itemize}
++		\item Parametre
++		\begin{itemize}
++			\item Pass-by-reference
++			\item Pass-by-value
++		\end{itemize}
++		\item Single return
++	\end{itemize}
++	\item Statiske typer
++	\item Elementære datatyper
++	\begin{itemize}
++		\item Heltal
++		\item Flyende kommatal
++		\item Tegn
++		\item Booleske værdier
++		\item Streng
++	\end{itemize}
++	\item Mængder
++	\item Kontrolstrukturer
++	\begin{itemize}
++		\item Iterative
++		\begin{itemize}
++			\item While
++			\item Foreach
++		\end{itemize}
++		\item Selektive
++		\begin{itemize}
++			\item If
++			\item Else if
++			\item Else
++		\end{itemize}
++	\end{itemize}
++	\item Logiske udtryk
++	\begin{itemize}
++		\item And
++		\item Or
++		\item Not
++		\item Relationelle udtryk
++		\begin{itemize}
++			\item <
++			\item >
++			\item <=
++			\item >=
++			\item ==
++			\item !=
++		\end{itemize}
++	\end{itemize}
++	\item Assertions og løkkeinvarianter
++	\item Garbage collection
++	\item Grafer
++	\begin{itemize}
++		\item Kanter
++		\item Knuder
++		\item Initialisering
++		\item Attributer på knuder og kanter
++		\item Grafoperationer
++		\begin{itemize}
++			\item Addere kunde og kant til graf
++			\item Union to grafer
++			\item Subtrahere knude, kant og graf til graf
++		\end{itemize}
++		\item Nabomængde til knuder i en graf
++	\end{itemize}
++\end{itemize}
++
++\section{Should have}
++\begin{itemize}
++	\item Funktioner på grafer, knuder og kanter (Eks. \texttt{G.count();})
++	\item Induceret subgraf
++	\item Enum
++	\item Switch 
++	\item Grafer
++	\begin{itemize}
++		\item Join
++		\item Komplement
++		\item Mulighed for at få naborepræsentationerne (Nabomatrice, naboliste)
++		\item Orden
++		\item Antal kanter
++	\end{itemize}
++	\item Funktioner som parametre til funktioner
++\end{itemize}
++
++\section{Could have}
++\begin{itemize}
++	\item Grafer
++	\begin{itemize}
++		\item Kartetisk produkt
++		\item $ K_n $ Komplet graf
++		\item $ C_n $ Cyklisk graf
++		\item $ P_n $ Vejgraf
++	\end{itemize}
++	\item Generics
++	\item Array
++	\item Multiple return
++\end{itemize}
++
++\section{Won’t have}
++\begin{itemize}
++	\item Error handling
++\end{itemize}
+\ No newline at end of file
+diff --git a/Rapport/sections/appendix/bnf.tex b/Rapport/sections/appendix/bnf.tex
+new file mode 100644
+index 0000000..1164656
+--- /dev/null
++++ b/Rapport/sections/appendix/bnf.tex
+@@ -0,0 +1,87 @@
++\begin{bnf*}
++\bnfprod{Prog}{\bnfpn{Cmds}}\\
++\bnfprod{Cmds}{\bnfpn{Cmd}\bnfpn{Cmds} \bnfor \bnfes}\\
++\bnfprod{Cmd}{\bnfpn{Stmt}\bnfor\bnfpn{Dcl}}\\
++\bnfprod{Dcl}{\bnfpn{VarDcl} \bnfor \bnfpn{FuncDcl} \bnfor \bnfpn{EnumDcl}}\\
++\bnfprod{VarDcl}{\bnfpn{Type} \bnfsp \bnfpn{Id} \bnfsp \bnfpn{InitOpt} \bnfts{ ; } }\\
++\bnfprod{InitOpt}{\bnfts{ = }\bnfpn{Expr} \bnfor \bnfes }\\
++\bnfprod{Stmt}{\bnfpn{AssignStmt} \bnfts{ ; } \bnfor \bnfpn{ReturnStmt} \bnfts{ ; } \bnfor \bnfpn{WhileStmt} \bnfnlor \bnfpn{ForEachStmt} \bnfor \bnfpn{IfStmt} } \bnfor \bnfpn{AssertStmt} \bnfts{ ; } \\
++\bnfprod{ArithExpr}{\bnfpn{ArithExpr} \bnfpn{ArithOp} \bnfpn{Term} \bnfor \bnfpn{Term}}\\
++\bnfprod{ArithOp}{\bnfts{+} \bnfor \bnfts{-}}\\
++\bnfprod{Term}{\bnfpn{Term} \bnfsp\bnfpn{TermOp}\bnfsp \bnfpn{Factor} \bnfor \bnfpn{Factor}}\\
++\bnfprod{TermOp}{\bnfts{*} \bnfor \bnfts{/} \bnfor \bnfts{\%}}\\
++\bnfprod{Factor}{\bnfts{(}\bnfpn{ArithExpr}\bnfts{)}
++		\bnfor \bnfpn{Field} \bnfor \bnfpn{FuncCall} \bnfor \bnfpn{IntLiteral} \bnfnlor \bnfpn{FloatLiteral} \bnfor \bnfpn{Cardinality} \bnfor \bnfpn{NumEdges}}\\
++\bnfprod{Id}{id}\\
++\bnfprod{Field}{\bnfpn{Id} \bnfor \bnfpn{Field}\bnfts{.}\bnfpn{Id}}\\
++\bnfprod{Expr}{\bnfpn{ArithExpr} \bnfor \bnfpn{OrExpr} \bnfor \bnfpn{GraphLit} \bnfor \bnfpn{EdgeLit} \bnfnlor \bnfpn{VertexLit} \bnfor \bnfpn{StringLiteral} \bnfor \bnfpn{CharLiteral}}\\
++%\bnfprod{LogicExpr}{\bnfpn{OrExpr} }\\
++\bnfprod{OrExpr}{\bnfpn{AndExpr} \bnfor \bnfpn{OrExpr} \bnfsp \bnfts{or}\bnfsp \bnfpn{AndExpr}}\\
++\bnfprod{AndExpr}{\bnfpn{NotExpr} \bnfor \bnfpn{AndExpr} \bnfsp\bnfts{and}\bnfsp \bnfpn{NotExpr}}\\
++\bnfprod{NotExpr}{\bnfts{not} \bnfsp \bnfpn{RelExpr} \bnfor \bnfpn{RelExpr}}\\
++\end{bnf*}
++
++\begin{bnf*}
++\bnfprod{RelExpr}{\bnfts{(} \bnfpn{OrExpr} \bnfts{)} \bnfor \bnfpn{BoolLiteral} \bnfor \bnfpn{Field} \bnfnlor \bnfpn{ArithExpr} \bnfpn{RelOp} \bnfpn{ArithExpr}\bnfor \bnfpn{ElementInSet}}\\
++\bnfprod{RelOp}{\bnfts{<} \bnfor \bnfts{<=} \bnfor \bnfts{>} \bnfor\bnfts{>=} \bnfor\bnfts{==} \bnfor \bnfts{!=} }\\
++\bnfprod{AssignStmt}{\bnfpn{Id} \bnfts{=} \bnfpn{ByValue} \bnfpn{Expr}}\\
++\bnfprod{GraphLit}{\bnfpn{GraphType}\bnfts{ \{ } \bnfpn{GraphStmtList} \bnfts{ \} }}\\
++\bnfprod{GraphType}{\bnfts{graph} \bnfor \bnfts{digraph}}\\
++\bnfprod{GraphStmtList}{\bnfpn{GraphStmt} \bnfts{ ; } \bnfpn{GraphStmtList} \bnfor \bnfes}\\
++\bnfprod{GraphStmt}{\bnfpn{EdgeStmt} \bnfor \bnfpn{VertexStmt} \bnfor \bnfpn{GraphAttrDcl}  } \\
++\bnfprod{EdgeStmt}{\bnfpn{Id} \bnfpn{EdgeOp} \bnfpn{EdgeStmtAux} \bnfpn{EdgeAttrList}}\\
++\bnfprod{EdgeStmtAux}{\bnfpn{Id} \bnfpn{EdgeOp} \bnfpn{EdgeStmtAux} \bnfor \bnfpn{Id} }\\
++\bnfprod{EdgeAttrList}{\bnfts{[ } \bnfpn{EdgeAttrAux} \bnfts{ ] }\bnfor \bnfes}\\
++\bnfprod{EdgeAttrAux}{\bnfpn{EdgeAttr} \bnfts{ , } \bnfpn{EdgeAttrAux} \bnfor \bnfpn{EdgeAttr}}\\
++\bnfprod{EdgeAttr}{\bnfpn{Id} \bnfts{ = } \bnfpn{EdgeAttrRHS}}\\
++\bnfprod{EdgeAttrRHS}{\bnfpn{Expr} \bnfor \bnfts{ \{ } \bnfpn{EdgeAttrVals} \bnfts{ \} } }\\
++%Expr eller EdgeAttrVal? 
++\bnfprod{EdgeAttrVals}{\bnfpn{Expr} \bnfts{ , } \bnfpn{EdgeAttrVals} \bnfor \bnfpn{Expr}}\\
++\bnfprod{EdgeOp}{\bnfts{-}\bnfts{-} \bnfor \bnfts{->} \bnfor \bnfts{<->}}\\
++\bnfprod{VertexStmt}{\bnfpn{Id}\bnfpn{SimpleAttrList}}\\
++%\bnfprod{GraphAttrAssign}{\bnfpn{Id} \bnfpn{GraphAttrStmts}}\\
++\bnfprod{GraphAttrDcl}{\bnfpn{VertEdgeKW} \bnfpn{VarDcl} }\\
++\bnfprod{VertEdgeKW}{\bnfts{vertex} \bnfor \bnfts{edge}}\\
++\bnfprod{Type}{\bnfts{int} \bnfor \bnfts{char} \bnfor \bnfts{bool} \bnfor \bnfts{float} \bnfor \bnfts{string} \bnfnlor \bnfts{vertex} \bnfor \bnfts{edge} \bnfor \bnfpn{GraphType}}\\
++\bnfprod{EdgeLit}{\bnfts{edge \{ } \bnfpn{Id}\bnfpn{EdgeOp}\bnfpn{Id} \bnfpn{SimpleAttrList} \bnfts{ \}} }\\
++\bnfprod{SimpleAttrList}{ \bnfts{[ } \bnfpn{SimpleAttr} \bnfts{ ]} \bnfor \bnfes}\\
++\bnfprod{SimpleAttr}{\bnfpn{AssignStmt} \bnfts{ , } \bnfpn{SimpleAttr} \bnfor \bnfpn{AssignStmt}}\\
++\bnfprod{VertexLit}{\bnfts{vertex \{ } \bnfpn{VertexStmt} \bnfts{  \} } }\\
++\bnfprod{FuncDcl}{\bnfpn{Type} \bnfpn{Id} \bnfts{ ( } \bnfpn{FuncArgs} \bnfts{ ) } \bnfpn{Define} \bnfpn{Block}}\\
++\bnfprod{FuncArgs}{\bnfpn{FuncArgList} \bnfor \bnfes}\\
++\bnfprod{FuncArgList}{\bnfpn{FuncArg} \bnfts{ , } \bnfpn{FuncArgList} \bnfor \bnfpn{FuncArg} }\\
++\bnfprod{FuncArg}{\bnfpn{ByValue} \bnfpn{Type} \bnfpn{Id}}\\
++\bnfprod{ByValue}{\bnfts{val} \bnfor \bnfes}\\
++\bnfprod{ReturnStmt}{\bnfts{return } \bnfpn{ReturnValue}}\\
++\bnfprod{ReturnValue}{\bnfpn{Expr} \bnfor \bnfes}\\
++\end{bnf*}
++
++\begin{bnf*}
++\bnfprod{FuncCall}{\bnfpn{Id} \bnfts{ ( } \bnfpn{FuncCallArgs}\bnfts{ ) }}\\
++\bnfprod{FuncCallArgs}{ \bnfpn{FuncCallArg} \bnfor \bnfes}\\
++\bnfprod{FuncCallArg}{\bnfpn{Expr} \bnfts{ , } \bnfpn{FuncCallArg} \bnfor \bnfpn{Expr}} \\
++\bnfprod{ForEachStmt}{\bnfts{for ( } \bnfpn{Type} \bnfsp \bnfpn{Id} \bnfts{ in } \bnfpn{Expr} \bnfts{ ) } \bnfpn{Invariant} \bnfsp \bnfpn{Block}}\\
++\bnfprod{WhileStmt}{\bnfts{while}  \bnfts{ ( } \bnfpn{OrExpr} \bnfts{ ) } \bnfpn{Invariant} \bnfsp \bnfpn{Block}}\\
++\bnfprod{Invariant}{\bnfts{invariant } \bnfpn{OrExpr} \bnfsp \bnfpn{AssertMessage} \bnfor \bnfes }\\
++\bnfprod{IfStmt}{\bnfts{if} \bnfts{ ( } \bnfpn{OrExpr} \bnfts{ ) } \bnfpn{Block} \bnfpn{Else} }\\
++\bnfprod{Else}{ \bnfts{else} \bnfsp \bnfpn{ElseBody}  \bnfor \bnfes}\\
++\bnfprod{ElseBody}{\bnfpn{IfStmt} \bnfor \bnfpn{Block}}\\
++\bnfprod{Block}{\bnfts{ \{ } \bnfpn{FuncCmds} \bnfts{ \}}}\\
++\bnfprod{FuncCmd}{\bnfpn{VarDcl} \bnfor \bnfpn{Stmt}}\\
++\bnfprod{FuncCmds}{\bnfpn{FuncCmd} \bnfpn{FuncCmds} \bnfor \bnfes}\\
++\bnfprod{DefineList}{\bnfpn{Define} \bnfsp \bnfpn{DefineList} \bnfor \bnfes}\\
++\bnfprod{Define}{\bnfts{define ( } \bnfpn{Id} \bnfts{ ) \{ }  \bnfpn{DefineStmtList}   \bnfts{ \}} }\\
++\bnfprod{DefineStmtList}{\bnfpn{GraphAttrDcl} \bnfts{ ; } \bnfpn{DefineStmtList} \bnfor \bnfes}\\
++\bnfprod{AssertStmt}{\bnfts{assert } \bnfpn{OrExp} \bnfpn{AssertMessage}}\\
++\bnfprod{AssertMessage}{\bnfts{,} \bnfpn{StringLiteral} \bnfor \bnfes}\\
++\bnfprod{VertexSet}{\bnfts{V( }\bnfpn{Id} \bnfts{ )}}\\ %V(G)
++\bnfprod{EdgesSet}{\bnfts{E( }\bnfpn{Id} \bnfts{ )}}\\ %E(G)
++\bnfprod{EnumDcl}{\bnfts{enum \{} \bnfpn{EnumList} \bnfts{\}}}\\
++\bnfprod{EnumList}{\bnfpn{Type} \bnfpn{Id} \bnfts{;} \bnfpn{EnumList} \bnfor \bnfes}\\
++\bnfprod{Cardinality}{\bnfts{|}\bnfpn{Expr}\bnfts{|}}\\ % or order
++\bnfprod{NumEdges}{\bnfts{||}\bnfpn{Expr}\bnfts{||}}\\
++\bnfprod{Adjacent}{\bnfpn{Id}\bnfts{.adj[ } \bnfpn{Id} \bnfts{ ] }}\\
++\bnfprod{ElementInSet}{\bnfpn{Id}\bnfts{ in }\bnfpn{Id}}\\
++\end{bnf*}
++
++
+diff --git a/Rapport/sections/bilag.tex b/Rapport/sections/bilag.tex
+new file mode 100644
+index 0000000..8b13789
+--- /dev/null
++++ b/Rapport/sections/bilag.tex
+@@ -0,0 +1 @@
++
+diff --git a/Rapport/sections/problemanalyse.tex b/Rapport/sections/problemanalyse.tex
+index 09c55f4..47ce8fa 100644
+--- a/Rapport/sections/problemanalyse.tex
++++ b/Rapport/sections/problemanalyse.tex
+@@ -1,5 +1,8 @@
+ \chapter{Problemanalyse}\label{sec:problemanalyse}
+ 
++\section{Eksisterende sprog til grafprogrammering}\label{sec:problemanalyse_stateoftheart}
++\input{sections/stateoftheart.tex}
++
+ \section{Grafteori}\label{sec:problemanalyse_grafteori}
+ \input{sections/problemanalyse/grafteori.tex}
+ 
+@@ -7,6 +10,9 @@
+ \todo[inline]{Bedre navn på afsnit?}
+ \input{sections/problemanalyse/graphproblems.tex}
+ 
+-\section{Målgruppe}
++\section{Målgruppe}\label{sec:problemanalyse_maalgruppe}
+ \input{sections/problemanalyse/maalgruppe.tex}
+ 
++\section{Problemformulering}
++\input{sections/problemanalyse/problemformulering.tex}
++
+diff --git a/Rapport/sections/problemanalyse/criteria.tex b/Rapport/sections/problemanalyse/criteria.tex
+new file mode 100644
+index 0000000..cdf10a7
+--- /dev/null
++++ b/Rapport/sections/problemanalyse/criteria.tex
+@@ -0,0 +1,13 @@
++\chapter{Løsningskriterer}
++For at kunne evaluere sproget, der udvikles i dette projekt, skal der opstilles kriterier for løsningen. 
++Disse kriterier inkluderer både generelle kriterier, som kan bestemme sprogets egenskaber, eksempelvis læsbarhed og ortogonalitet, og specifikke krav om inkludering af bestemt funktionalitet, eksempelvis førsteklasses funktioner eller en bestemt mængde af elementære datatyper.
++
++Første afsnit undersøge generelle kriterier for evaluering af sprog defineret af \citeauthor{Sebesta2016}\cite{Sebesta2016} samt prioriterer disse efter MoSCoW-skalaen for netop denne løsning.
++Andet afsnit gennemgår udvalgte ønskede funktionaliteter samt deres prioriteringen efter MoSCoW-skalaen.
++Alle ønskede funktionaliteter prioriteret efter MoSCoW-skalaen findes i bilag \ref{app:MoSCoW}.
++
++\section{Generelle kriterier}
++\input{sections/problemanalyse/generalcriteria.tex}
++
++\section{Funktionelle krav}
++\input{sections/problemanalyse/functionalrequirements.tex}
+\ No newline at end of file
+diff --git a/Rapport/sections/problemanalyse/functionalrequirements.tex b/Rapport/sections/problemanalyse/functionalrequirements.tex
+new file mode 100644
+index 0000000..dc2d34b
+--- /dev/null
++++ b/Rapport/sections/problemanalyse/functionalrequirements.tex
+@@ -0,0 +1,20 @@
++I dette afsnit vil et par af de funktionelle krav til vores programmeringssprog blive beskrevet og argumenteret for hvorfor vi har valgt at implementere dem i vores programmeringssprog. De valgte funktionelle krav er:
++\begin{itemize}
++	\item Mængder 
++	\item Kontrolstrukturer
++	\item Grafer
++\end{itemize} 
++\subsubsection*{Grafer}
++I vores programmeringssprog er det grundlægende princip at skulle arbejde med grafer og grafalgoritmer. Vi har valgt at bruge graf, som en primitiv datatype, hvilket betyder at datatypen bruges, som programmeringssprogets byggesten\cite{Sebesta2016}. Dette valg gør at vi kan bruge grafer, som en byggesten til at udvikle grafalgoritmer i vores programmeringssprog. Det gør det også nemmere for brugerene af sproget at håndtere forskellige grafer, hvis det er muligt at ændre på denne datatype.
++
++\subsubsection*{Mængder}
++Mængde beregninger er en essentiel del af graf beregningsteori og bruges ofte indenfor grafalgoritmer til at løse forskellige graf relaterede problemer\cite{CLRS2009}.
++I vores programmeringssprog skal det kunne være muligt kunne teste diverse graf algoritmer ved hjælp af mængde operationer.
++F.eks. ville det være nemmere for at beskrive en subgraf ved hjælpe af mængder operationer i stedet for at skulle bruge kontrolstrukturer til at beskrive, hvilke noder eller kanter der ikke skulle testes.
++
++\subsubsection*{Kontrolstrukturer}
++Kontrolstrukturer er en del af næsten alle programmeringssprog og er med til at styrer programmets flow igennem kørsels tiden. Der findes mange former for forskellige kontrolstrukturer, som har indflydelse på hvordan programmets flow kan optimeres. F.eks. har vi valgt at bruge en \textit{foreach} løkke i stedet for en \textit{for} løkke grundet diverse graf algoritmer, som findes. I disse graf algoritmer kan en \textit{foreach} løkke f.eks. bruges til at traversere den givne graf. 
++\tanker{Der skal nok skrives noget mere omkring grunden for foreach og andre kontrolstukturer.}     
++
++I dette afsnit er der blevet argumenteret for nogle af funktionelle krav, som dette programmeringssprog består af og hvorfor de er vigtige at have med. Dette er med til at skabe et godt grundlag for vores programmeringssprog.
++
+diff --git a/Rapport/sections/problemanalyse/generalcriteria.tex b/Rapport/sections/problemanalyse/generalcriteria.tex
+new file mode 100644
+index 0000000..be94c31
+--- /dev/null
++++ b/Rapport/sections/problemanalyse/generalcriteria.tex
+@@ -0,0 +1,49 @@
++\citeauthor{Sebasta2016} definerer tre generelle kriterier for evalueringen af sprog: læsbarhed, skrivebarhed, pålidelighed\cite{Sebesta2016}.
++Læsbarheden er et mål for, hvor let generel kode i et sprog er at læse og forstå\cite{Sebesta2016}.
++Skrivebarhed beskriver, hvor hurtigt, det er at skrive korrekt kode i et givent sprog\cite{Sebesta2016}.
++Pålidelighed er, om det er let at undgå eller håndtere fejl i et givent sprog\cite{Sebesta2016}.
++
++For sproget udviklet i dette projekt er læsbarhed og skrivbarhed af højere prioritet end pålidelighed, da sproget er beregnet til prototypeudvikling, og ikke et produktionsmiljø.
++
++Der findes karakteristika, som påvirker disse kriterier.
++\citeauthor{Sebesta2016} definerer ni karakteristika, hvoraf flest påvirker pålideligheden af sproget, næstflest påvirker skrivbarheden og færrest påvirker læsbarheden\cite{Sebesta2016}.
++Disse vægtes, så læs- og skrivbarhed prioriteres højt.
++
++Simplicitet beskriver, hvor simpelt det er at lære eller forstå sproget\cite{Sebesta2016}.
++Eksempelvis påvirker antallet af grundlæggende konstruktioner simpliciteten.
++Dette har prioriteres som et ''Must have'', da sproget skal bruges som til at prototype, og derfor skal det være hurtigt at lære.
++
++Ortogonalitet handler om at kombinere primitive sproglige konstruktioner til mere kompleks funktionalitet\cite{Sebesta2016}.
++Det betyder, at det er lettere at lære samt læse sproget, da programmører kun behøver at lære en relativt lille mængde af operationer for at forstå komplekse funktionaliteter.
++Dette prioriteres som et ''Should have'', da sproget skal være let at lære, men det ikke er påkrævet for at være anvendeligt.
++
++Datatyper er tildeling af typer til hver variabel\cite{Sebesta2016}.
++Fordel herved er, at den semantiske mening med en variabel indkodes tættere, end hvis typen ikke er kendt.
++Dette prioriteres som et ''Must have'', da sproget skal være logisk opbygget, så variabler afspejler grafteorien, hvor en variabel eller attribut godt kan have en type.
++
++Design af syntaks beskriver, hvor stor forståeligheden af de individuelle konstruktioner er\cite{Sebesta2016}.
++Eksempelvis hvis sproget tillader at overskrive nøgleord, så kan det resultere i forvirring for programmøren.
++Forståelighed prioriteres som et ''Must have'', da det skal være let at læse algoritmer skrevet af andre i sproget.
++
++Abstraktion handler om at indkapsle funktionalitet, så programmøren ikke behøver at tænke på aspekter, som er irrelevant for et given abstraktionsniveau.
++Eksempelvis er allokering af hukommelse et meget lavere abstraktionsniveau, end design af algoritmer, og derfor bør disse adskilles ved abstraktion.
++Dette prioriteres derfor som et ''Must have''.
++
++Udtrykkelighed er hvor let, det er at udtrykke en mening sproget\cite{Sebesta2016}.
++SQL er et eksempel herpå, hvor kraftfulde operationer kan udtrykkes med få mindre konstruktioner.
++Dette prioriteres som et ''Could have'', da det vil gøre noget af udviklingen lettere, men ved at være eksplicit om udvalgte konstruktioner, vil koden mere ligne pseudokode, hvilket er ønskværdigt i et prototypesprog.
++
++Typetjek er at test for typefejl under kompilering eller eksekvering af kode\cite{Sebesta2016}.
++Dette er fordelagtigt i sproget, da det kan bruges til at opdage fejl i algoritmen, som ønskes testet.
++Derfor prioriteres dette som et ''Must have''.
++
++Fejlhåndtering tillader programmøren at gendanne et tilladt tilstand, såfremt en fejl sker\cite{Sebesta2016}.
++Dette er ikke ikke ønsket under udviklingen af en prototype, fordi fejl så vidt muligt bør fjernes inden, systemet skal bruges i et produktionsmiljø.
++Derfor prioriteres dette som et ''Won't have''.
++
++Det sidste karakteristika, aliasing, betyder, at to eller flere navne referer til samme hukommelseslokation\cite{Sebesta2016}.
++Dette betragtes som skadeligt, og derfor bør dette undgås. 
++Derfor bør sproget have enten helt undgå aliasing eller have konstruktioner til at undgå aliasing, hvorfor dette prioriteres som et ''Must have''.
++
++På baggrund af disse generelle kriterier og karakteristika kan nogle af de funktionelle krav nu vægtes.
++De resterende funktionelle krav kan vægtes på baggrund af problemanalysen.
+\ No newline at end of file
+diff --git a/Rapport/sections/problemanalyse/maalgruppe.tex b/Rapport/sections/problemanalyse/maalgruppe.tex
+index 6002486..a556ca8 100644
+--- a/Rapport/sections/problemanalyse/maalgruppe.tex
++++ b/Rapport/sections/problemanalyse/maalgruppe.tex
+@@ -9,12 +9,12 @@ Det kunne eksempelvis være:
+ 
+ \begin{itemize}
+ 	\item Softwareudviklere, som udvikler grafalgoritmer til at løse praktiske problemer,
+-	\item Matematikere, som bruger grafteori på et teoretisk plan\cite{MatStudieordning},
++	\item Matematikere, som bruger grafteori på et teoretisk plan,
+ 	\item Dataloger, som kan løse både teoretiske og praktiske problemer.
+ \end{itemize}
+ 
+ Et fælles kendetegn for disse personer er, at de har kendskab til programmering.
+-Dette betyder, at disse er bekendt med grundlæggende datalogiske begreber og har erfaring i at skrive programmer efter en fast syntaks, og såfremt et sprog ligner andre sprog, som målgruppen kender, bør læringskurven for programmeringssproget være forholdsvis lav. 
++Dette betyder, at disse er bekendt med grundlæggende datalogiske begreber og har erfaring i at skrive programmer efter en fast syntaks\cite{MatStudieordning}, og såfremt et sprog ligner andre sprog, som målgruppen kender, bør læringskurven for programmeringssproget være forholdsvis lav. 
+ Desuden antages det, at disse har en viden om grafteori, da emnet er grundlæggende for datalogi og matematik\cite{Rosen2013}.
+ Derfor skal den korrekt terminologi anvendes inden for emnet, således det er muligt for brugeren at udtrykke sig konkret indenfor terminologien.
+ Derudover er det en mulighed at anvende den matematiske notation for sproglige konstruktioner, som opererer på grafer.
+diff --git a/Rapport/sections/problemanalyse/problemformulering.tex b/Rapport/sections/problemanalyse/problemformulering.tex
+new file mode 100644
+index 0000000..dfd3c34
+--- /dev/null
++++ b/Rapport/sections/problemanalyse/problemformulering.tex
+@@ -0,0 +1,25 @@
++I dette afsnit vil problemformuleringen blive præsenteret med begrundelse for underspørgsmålene.
++Som præsenteret i afsnit \todo{ref} så er det overordnede mål med sproget at understøtte udvikling og prototyping af grafalgoritmer.
++Dette leder op til det overordnede spørgsmål i problemformuleringen:
++\begin{quote}
++	\textbf{\textit{Hvordan udvikles et sprog der understøtter udvikling og prototyping af grafalgoritmer?}}
++\end{quote}
++For nemmere at kunne besvare det overordnede spørgsmål er der formuleret en række underspørgsmål.
++I afsnit \todo{ref} blev vigtigheden af læselighed og skrivbarhed af sprog udforsket, og på baggrund af dette afsnit er følgende underspørgsmål blevet fremsat:
++\begin{quote}
++	\textit{Hvordan kan sprogets syntaks skrivbart og læseligt understøtte grafer og grafalgoritmer?}
++\end{quote}
++På baggrund af afsnit \ref{sec:problemanalyse_maalgruppe} fremgår det at den primære målgruppe for projektet er softwareudviklere, matematikere og dataloger.
++Denne målgruppe har kendskab til grafer i en matematisk kontekst, og har erfaring med at programmere i et eller flere af de eksisterende sprog, jf. afsnit \ref{sec:problemanalyse_maalgruppe}.
++Derfor vil det være fordelagtigt hvis sproget dels trækker på syntaks fra matematikken, og dels syntaks fra eksisterende programmeringssprog.
++Dette har ledt til følgende underspørgsmål:
++\begin{quote}
++	\textit{Hvordan kan sproget understøtte eksisterende koncepter for bearbejdning af grafer, både fra matematikken samt eksisterende programmeringssprog til repræsentation af grafer?}
++\end{quote}
++Da sproget skal understøtte udvikling og prototyping af grafalgoritmer, er det også vigtigt at der bliver givet beskrivende fejlbeskeder.
++Hvilket leder til underspørgsmålet:
++\begin{quote}
++	\textit{Hvordan kan sproget sikre at fejlbeskeder bliver beskrivende og fyldestgørende?}
++\end{quote}
++
++Den ovenstående problemformulering samt de efterfølgende underspørgsmål vil danne fundamentet for denne rapport.
+\ No newline at end of file
+diff --git a/Rapport/sections/sections/problemanalyse/functionalrequirements.tex b/Rapport/sections/sections/problemanalyse/functionalrequirements.tex
+new file mode 100644
+index 0000000..e69de29
+diff --git a/Rapport/sections/sections/problemanalyse/generalcriteria.tex b/Rapport/sections/sections/problemanalyse/generalcriteria.tex
+new file mode 100644
+index 0000000..e69de29
+diff --git a/Rapport/sections/spec/backnaur.tex b/Rapport/sections/spec/backnaur.tex
+new file mode 100644
+index 0000000..5c0fe8e
+--- /dev/null
++++ b/Rapport/sections/spec/backnaur.tex
+@@ -0,0 +1,58 @@
++\tanker[inline]{Dette afsnit har afveget fra hvad overskriften siger. Ved ikke om der ønskes en slavisk gennemgang af CFG'en, men dette afsnit går mere ind og fortæller om muligheder i sproget, både som defineret af CFG'en og nogle semantiske overvejelser.}
++Der er til sproget udarbejdet en \gls{cfg} i \gls{bnf}, denne kan ses i bilag \ref{app:bnf}.
++Sproget er et imparativt programmeringssprog, med en syntax der minder om den fra C.
++Foruden dette indeholder den grafer som førstehånds objekter, disse erklæres med en syntaks der minder om DOT fra Graphviz, se \cite{Gansner00}.
++Nu vil de forskellige sproglige konstruktioner som grammatikken understøtter blive præsenteret.
++
++Grammatikken understøtter følgende typer ved de specificerede nøgleord: heltal (\texttt{int}), tegn (\texttt{char}), boolske typer (\texttt{bool}), flydende komma tal (\texttt{float}), graf knuder (\texttt{vertex}), graf kanter (\texttt{edge}) samt uorienterede og orienterede grafer (hhv. \texttt{graph} og \texttt{digraph}).
++Der er defineret aritmetiske operationer på heltal og flydende komma tal.
++De muligt aritmetiske operationer i sproget, angivet ved infix notation, er: Addition (\texttt{+}), subtraktion (\texttt{-}), multiplikation (\texttt{*}), division (\texttt{/}) og modulo (\texttt{\%}). 
++Der er også et subset af de aritmetiske operationer defineret mellem grafer og knuder, kanter eller grafer.
++De mulige aritmetiske operationer er addition og subtraktion.
++
++Grafer defineres i sproget ved en DOT-agtig syntaks, jf. afsnit \ref{sec:problemanalyse_stateoftheart_dot}\todo{Lav label og ref}, med tilføjelse af en operator mellem kanter, \texttt{<->}, til at indikere at en kant går begge veje. 
++Attributter på grafer erklæres på samme måde som variable, men præfikses med \texttt{vertex} og \texttt{edge} for attributter på hhv. knuder og kanter, se linje \ref{lstline:specifikation_cfg_grafeksempel_attrdclstart}-\ref{lstline:specifikation_cfg_grafeksempel_attrdclend} i listing \ref{lst:specifikation_cfg_grafeksempel}. 
++Attributter kan tildeles værdier enten som standardværdier ved erklæring eller ved en attribut-liste indkapslet i \texttt{[ ]}.
++I funktioner er det muligt at erklære nye attributter på en graf ved \texttt{define} syntaksen, der kan ses i listing \ref{lst:specifikation_cfg_grafattributeksempel}. 
++I et \texttt{define}-udtryk erklæres nye attributter på samme vis som i erklæringen af en graf, og attributterne kan derefter benyttes, se linje \ref{lstline_specifikation_cfg_grafattributeksempel_assign}.
++Knude- og kantmængden af en graf G kan tilgås ved hhv. \texttt{V(G)} og \texttt{E(G)}, tilsvarende den matematiske notation. 
++Ligeledes kan antallet af knuder og kanter tilgås ved hhv. \texttt{|G|} og \texttt{||G||} for en graf G. 
++
++Sproget indeholder procedurer og kontrolstrukturer, der i høj grad minder om tilsvarende fra C, navnligt \texttt{if} og \texttt{while}\todo{Opdater, hvis switch inkluderes}, samt et \texttt{for}-udtryk, der semantisk svarer til \texttt{foreach} fra \CS/. 
++Alle kontrolstrukturer kræver eksplicitte blokke for at undgå dangling-else problemet, jf. afsnit \ref{sec:problemanalyse_parserteori_problematikker}\tanker{Dokumenteres problemet? Er det nødvendigt at nævne dangling else, eller skal vi undlade at nævne det?}.
++Lovlig og ulovlig brug af kontrolstrukturer ses i listing hhv. \ref{lst:specifikation_cfg_kontrolstrukturer_lovlig} og \ref{lst:specifikation_cfg_kontrolstrukturer_ulovlig}.
++På løkkerne, dvs. \texttt{while} og \texttt{for}, er det desuden muligt at specificere løkke-invarianter, der tjekkes før hver iteration af løkken og efter løkken terminerer\tanker{Er usikker på, hvad præcis invarianter i sproget skal gøre, hvilket gør det svært for mig at komme med et godt eksempel \textit{//Nikolaj}}. 
++Et eksempel på syntaksen for \texttt{for}-løkker kan ses i listing \ref{lst:specifikation_cfg_grafattributeksempel} på linje \ref{lstline:specifikation_cfg_forloopeksempel}.
++
++\begin{figure*}
++	\lstinputlisting[caption={Eksempel på graferklæring i sproget.},label={lst:specifikation_cfg_grafeksempel},escapechar=¤]{listings/knud/graphdclexample.tex}
++\end{figure*}
++
++\begin{figure*}
++	\lstinputlisting[caption={Eksempel på tilføjelse af nye attributter},label={lst:specifikation_cfg_grafattributeksempel},escapechar=¤]{listings/knud/graphattributeaddition.tex}
++\end{figure*}
++
++\begin{figure*}
++\begin{minipage}[b]{0.45\textwidth}
++	\lstinputlisting[caption={Legal syntaks: Eksplicit blok.},label={lst:specifikation_cfg_kontrolstrukturer_lovlig},escapechar=¤]{listings/knud/blocklegal.tex}
++\end{minipage}
++\hfill
++\begin{minipage}[b]{0.45\textwidth}
++	\lstinputlisting[caption={Illegal syntaks: Ingen blok.},label={lst:specifikation_cfg_kontrolstrukturer_ulovlig},escapechar=¤]{listings/knud/blockillegal.tex}
++\end{minipage}
++\end{figure*}
++
++%\begin{figure*}
++%	\lstinputlisting[caption={Eksempel på løkke-invariant og \texttt{for}-løkke}, label={lst:specifikation_cfg_invariant},escapechar=¤]{listings/knud/invariant.tex}
++%\end{figure*}
++
++\begin{table}
++	\centering
++	\input{figures/tables/lexemes.tex}
++	\caption{Regulære udtryk for tokens.}
++	\label{tab:specifikation_cfg_lexemes}
++\end{table}
++
++
++
++
+diff --git a/Rapport/sections/specifikation.tex b/Rapport/sections/specifikation.tex
+index 3355564..4fee3e1 100644
+--- a/Rapport/sections/specifikation.tex
++++ b/Rapport/sections/specifikation.tex
+@@ -1 +1,4 @@
+-\chapter{Specifikation af sproget}\label{sec:specifikation}
+\ No newline at end of file
++\chapter{Specifikation af sproget}\label{sec:specifikation}
++
++\section{Backus-Naur form}
++\input{sections/spec/backnaur.tex}
+\ No newline at end of file
+diff --git a/Rapport/sections/stateoftheart.tex b/Rapport/sections/stateoftheart.tex
+new file mode 100644
+index 0000000..721839c
+--- /dev/null
++++ b/Rapport/sections/stateoftheart.tex
+@@ -0,0 +1,100 @@
++%Metatekst
++%\tanker[inline]{Afsnit bør omstruktureres, så fordele og ulemper står sammen efterfulgt af samlet tekst.}
++Til at repræsentere og arbejde med grafer har en programmør flere muligheder afhængigt af hvilket programmeringssprog der benyttes.
++Eksempler herpå vil nu blive gennemgået for sprogene C, GP og DOT.
++Formålet er at undersøge, hvilke funktionaliteter et nyt sprog bør have, samt hvilke der ikke er nødvendige.
++
++\subsection{Programmering med grafer i C}
++%Intro
++I C vil en graf blive repræsenteret i form af en nabomatrix eller nabolister, jf. afsnit \ref{app:graf-i-C}.
++Dette kan repræsenteres med \texttt{struct}-datatypen.
++Da grafrepræsentation med \texttt{struct}-datatypen skal defineres, betyder det, at programmøren bestemmer den interne repræsentation, hvilket ikke er i overensstemmelse med abstraktionsniveauet grafer afspejler.
++%Fordele
++\subsubsection*{Fordele ved at bruge C til grafer}
++\begin{itemize}
++	\item God ydelse\cite{LanguageBenchmark}.
++	\item Høj platformsuafhængighed\cite{Sebesta2016}.
++	\item Fleksibilitet ved at bestemme den interne repræsentation.
++\end{itemize}
++
++%Ulemper
++\subsubsection*{Ulemper ved at bruge C til grafer}
++I bilag \ref{lst:app:problemanalyse_stateoftheart_cgraf} er der et eksempel på en simpel implementering af en graf og funktionalitet til at tilføje kanter til den i C. 
++Det kræver meget kode at repræsentere en simpel graf i C.
++Der er ingen generel syntaks for repræsentation af grafer, og en programmør er derfor nød til konstruere repræsentationen selv, hvilket medfører:
++\begin{itemize}
++	\item Reduceret produktivitet.
++	\item Lavere abstraktionsniveau.
++\end{itemize}
++
++Ved at benytte C til at repræsentere grafer, vil fordelene være høj ydelse og fleksibilitet, da programmøren har kontrol over den interne repræsentation og kan derved formindske overhead. 
++Disse fordele er dog på bekostning af reduceret produktivitet, da alle aspekter skal skrives manuelt, samt lavere abstraktionsniveau, hvilket resulterer i, at det måske er sværere at forstå og løse en given problemstilling.
++Det er muligt at anvende et bibliotek til at håndtere konstruktionen af grafer\cite{North2014}.
++%Dette er dog stadig et lavere abstraktionsniveau end grafteori, da programmøren f.eks. skal tænke over pointere.
++%Andre programmeringssprog med højere abstraktionsniveau, såsom Java eller \CS/, kan afhjælpe nogle af problemerne, ved eksempelvis bedre fejlhåndtering end fejlkoder, men skal stadig benytte en eksplicit repræsentation af graferne. 
++%\todo[inline]{Syntes der bliver brugt for lidt energi på biblioteket. Hvorfor er der ikke et kodeeksempel på dette, og hvilke fordele/ulemper er der ved det? Hvis Java eller CS fikser de nævnte problemer, hvorfor er de så ikke overvejet nærmere?}
++%\todo[inline]{Synes det vil være for meget i et state of the art afsnit at gå i dybden med bibliotekerne, og C afsnittet er i forvejen ret langt. Vil dog også mene at den sidste pointe med Java og CS ikke er afsluttet. Jeg stemmer for at det bliver fjernet, da hvis vi begynder at beskrive Java og CS tilgang til graf programmering har vi efterhånden ret mange eksisterende løsninger.}
++
++\subsection{GP}
++%\todo[inline]{Afsnit savner en pæn figur af GP, så man kan se, hvordan det ser ud.}
++GP er et graforienteret sprog, som fokuserer på visualisering af grafer og problemløsning med grafer, eksempelvis transitiv lukning og den inverse graf\cite{Plump2009}.
++GP har en grafisk brugergrænseflade, som gør det nemmere for programmøren at lave grafer og abstrahere fra den interne repræsentation\cite{Plump2009}.
++Instruktioner i GP kaldes transformationer, som ændrerer på en graf i henhold til kildekoden, hvilket sker via en brugergrænseflade\cite{Plump2009}. Denne brugergrænseflade er med til at skabe en visuelt billede af grafen, som bliver konstrueret.
++%\todo{Hvornår sker interfacet med et program med andet end en brugergrænseflade? Hvad er der så specielt ved GP's ''grafiske'' brugergrænse flade i forhold til at bruge et tekst editor eller et IDE? Denne visuelle brugergrænseflade kunne måske også vises i rapporten.}.
++
++%Fordele
++\subsubsection*{Fordele ved at bruge GP til grafer}
++
++\begin{itemize}
++	\item Visuel brugergrænseflade.
++	\item Højt abstraktionsniveau.
++	\item Programmering med grafer som en serie af transformationer.
++\end{itemize}
++%Ulemper
++\subsubsection*{Ulemper ved at bruge GP til grafer}
++\begin{itemize}
++	\item Visuel brugergrænseflade skalerer dårligt\cite{GP2Issues}.
++	\item Fejl i compileren\cite{GP2Issues}.
++	\item Ingen standardimplementation af gængse grafalgoritmer\cite{Plump2009}.
++	\item Besværlig generalisering af algoritmer.
++\end{itemize}
++
++Den visuelle brugergrænseflade gør det nemt for programmøren at visualisere en graf og algoritmerne, hvilket medfører at abstraktionsniveauet bliver højere. 
++Desuden tvinger programmeringssproget programmøren til at tænke på problemstillingen som en serie af graftransformationer, hvilket er mere naturlig for grafer, kontra eksemplet fra c, som kan ses i listing \ref{lst:app:problemanalyse_stateoftheart_cgraf}. 
++Det gør abstraktionsniveauet højt, så programmøren ikke behøver at tænke på den interne repræsentation.
++Problemet er midlertidigt, at sproget er forholdsvis nyt\cite{Plump2009}, så der mangler standardimplementationer, og compileren er ikke færdig.
++Den visuelle brugergrænseflade skalerer også dårligt for store grafer, og GP indeholder ikke førsteklassesfunktioner eller funktionspointere, hvilket gør det besværligt at lave generelle algoritmer\cite{Plump2009}.
++%Gammel formulering; begge pointer er redundante pt.
++%Sidst er sproget meget specifikt, så det kræver en grafisk brugergrænseflade, og det er svært at generalisere algoritmer\todo{Citation needed}, hvoraf sidstnævnte vil være en fordel ved f.eks. Dijkstras algoritme, jf. afsnit \ref{sec:problemanalyse_graphproblems_shortestpath}\todo{Ref til Dijkstra afsnit når merged}, hvor vægten på en kant kan opfattes som en variabel på hver kant eller en funktion for vægten mellem to knuder.
++
++\subsection{DOT}
++DOT er et programmeringssprog, som bruges til at beskrive konstruktion og visualisering af grafer.  
++DOT er et deklarativt sprog, hvor grafen beskrives med knuder, kanter og subgrafer samt attributer på førnævnte.
++En fortolker kan på baggrund af disse konstruktioner tegne en graf, som repræsenterer det ønskede.
++Ved at anvende kode til at beskrive visualiseringen, behøves der ikke erfaring med grafiske designværktøjer for at kunne tegne en pæn visuel graf.
++DOT er begrænset til at kun beskrive grafer, og oversættes derfor ikke til nogen form for eksekverbar kode\cite{DOTGraphs}. 
++
++Et eksempel på DOT syntaksen kan ses i bilag \ref{app:DOT}.
++% Fordele og ulemper ved grafer
++\subsubsection*{Fordele ved at bruge DOT til grafer}
++DOT er som nævnt ovenfor et sprog beregnet til konstruktion og visualsering af grafer.
++Syntaksen er derfor god til at beskrive grafer, hvilket kan benyttes i et programmeringssprog, som bearbejder grafer.
++\begin{itemize}
++	\item God visualisering af grafer.
++	\item God syntaks til definitioner af grafer og attributter.
++\end{itemize}
++
++\subsubsection*{Ulemper ved at bruge DOT til grafer}
++DOT er selvsagt ikke egnet til programmering i sig selv, da det ikke producerer eksekverbar kode, og derfor håndterer sproget ikke problemstillinger ved operationer på grafer.
++Syntaksen kan, på trods af dets kortfattethed, være svær at overskue ved større grafer.
++Det kan eksempelvis være svært at afgøre, om to knuder er forbundet, ved blot at kigge på koden. DOT har dog mere fokus på det grafiske output hvilket kan have negative konsekvenser for større grafer.
++Dette kaldes også for lav læsbarhed.
++\begin{itemize}
++	\item Ingen eksekverbar kode.
++	\item Lav læsbarhed ved større grafer.
++\end{itemize}
++
++%Opsummering
++Syntaksen ved DOT gør det naturligt at beskrive grafer, men da DOT ikke bruges til ekskverbar kode, kan der være problemstillinger, sproget ikke håndterer.
++Derfor kan elementer fra DOTs syntaks benyttes og udvides med ønskede funktionaliteter til et sprog, der bearbejder grafer.
++\todo[inline]{Mangler en generel opsummering der nævner hvilke ting vi så vil have med i vores sprog.}
+\ No newline at end of file
+diff --git a/Rapport/setup/acronyms.tex b/Rapport/setup/acronyms.tex
+index bd717fd..f17394d 100644
+--- a/Rapport/setup/acronyms.tex
++++ b/Rapport/setup/acronyms.tex
+@@ -1,2 +1,4 @@
+ \newacronym{dag}{DAG}{directed acyclic graph}
+-\newacronym{mst}{MST}{minimum-weight spanning tree}
+\ No newline at end of file
++\newacronym{mst}{MST}{minimum-weight spanning tree}
++\newacronym{bnf}{BNF}{Backus-Naur form}
++\newacronym{cfg}{CFG}{Kontekst-fri grammatik}
+diff --git a/Rapport/setup/macros.tex b/Rapport/setup/macros.tex
+index 4b30b96..0acc307 100644
+--- a/Rapport/setup/macros.tex
++++ b/Rapport/setup/macros.tex
+@@ -190,4 +190,5 @@
+ \newcommand{\quotecut}{}
+ \def\quotecut/{\textnormal{[...]}}
+ 
+-\newcommand{\emptystring}{\epsilon}
+\ No newline at end of file
++\newcommand{\emptystring}{\epsilon}
++\newcommand{\bnfnlor}{\\&\bnfor &}
+\ No newline at end of file
+diff --git a/Rapport/setup/preamble.tex b/Rapport/setup/preamble.tex
+index d08ff15..68c9181 100644
+--- a/Rapport/setup/preamble.tex
++++ b/Rapport/setup/preamble.tex
+@@ -425,4 +425,5 @@ minimum height=2em]
+ \newenvironment{edges}{\begin{scope}[>={Latex[black,scale=1.2]}]
+ 	}{\end{scope}}
+ 
+-\usepackage[epsilon,tstt]{backnaur}	
+\ No newline at end of file
++\usepackage[epsilon,tstt]{backnaur}	
++\def\bnfpo{\rightarrow}
+\ No newline at end of file
+diff --git a/Statusseminar/.gitignore b/Statusseminar/.gitignore
+new file mode 100644
+index 0000000..054cc5a
+--- /dev/null
++++ b/Statusseminar/.gitignore
+@@ -0,0 +1,231 @@
++## Core latex/pdflatex auxiliary files:
++*.aux
++*.lof
++*.log
++*.lot
++*.fls
++*.out
++*.toc
++*.fmt
++*.fot
++*.cb
++*.cb2
++.*.lb
++
++## Intermediate documents:
++*.dvi
++*.xdv
++*-converted-to.*
++# these rules might exclude image files for figures etc.
++# *.ps
++# *.eps
++*.pdf
++
++## Working file
++WorkingFile.tex
++
++## Generated if empty string is given at "Please type another file name for output:"
++#.pdf
++
++## Bibliography auxiliary files (bibtex/biblatex/biber):
++*.bbl
++*.bcf
++*.blg
++*-blx.aux
++*-blx.bib
++*.run.xml
++
++## Build tool auxiliary files:
++*.fdb_latexmk
++*.synctex
++*.synctex(busy)
++*.synctex.gz
++*.synctex.gz(busy)
++*.pdfsync
++
++## Auxiliary and intermediate files from other packages:
++# algorithms
++*.alg
++*.loa
++
++# achemso
++acs-*.bib
++
++# amsthm
++*.thm
++
++# beamer
++*.nav
++*.pre
++*.snm
++*.vrb
++
++# changes
++*.soc
++
++# cprotect
++*.cpt
++
++# elsarticle (documentclass of Elsevier journals)
++*.spl
++
++# endnotes
++*.ent
++
++# fixme
++*.lox
++
++# feynmf/feynmp
++*.mf
++*.mp
++*.t[1-9]
++*.t[1-9][0-9]
++*.tfm
++
++#(r)(e)ledmac/(r)(e)ledpar
++*.end
++*.?end
++*.[1-9]
++*.[1-9][0-9]
++*.[1-9][0-9][0-9]
++*.[1-9]R
++*.[1-9][0-9]R
++*.[1-9][0-9][0-9]R
++*.eledsec[1-9]
++*.eledsec[1-9]R
++*.eledsec[1-9][0-9]
++*.eledsec[1-9][0-9]R
++*.eledsec[1-9][0-9][0-9]
++*.eledsec[1-9][0-9][0-9]R
++
++# glossaries
++*.acn
++*.acr
++*.glg
++*.glo
++*.gls
++*.glsdefs
++
++# gnuplottex
++*-gnuplottex-*
++
++# gregoriotex
++*.gaux
++*.gtex
++
++# hyperref
++*.brf
++
++# knitr
++*-concordance.tex
++# TODO Comment the next line if you want to keep your tikz graphics files
++*.tikz
++*-tikzDictionary
++
++# listings
++*.lol
++
++# makeidx
++*.idx
++*.ilg
++*.ind
++*.ist
++
++# minitoc
++*.maf
++*.mlf
++*.mlt
++*.mtc[0-9]*
++*.slf[0-9]*
++*.slt[0-9]*
++*.stc[0-9]*
++
++# minted
++_minted*
++*.pyg
++
++# morewrites
++*.mw
++
++# nomencl
++*.nlo
++
++# pax
++*.pax
++
++# pdfpcnotes
++*.pdfpc
++
++# sagetex
++*.sagetex.sage
++*.sagetex.py
++*.sagetex.scmd
++
++# scrwfile
++*.wrt
++
++# sympy
++*.sout
++*.sympy
++sympy-plots-for-*.tex/
++
++# pdfcomment
++*.upa
++*.upb
++
++# pythontex
++*.pytxcode
++pythontex-files-*/
++
++# thmtools
++*.loe
++
++# TikZ & PGF
++*.dpth
++*.md5
++*.auxlock
++
++# todonotes
++*.tdo
++
++# easy-todo
++*.lod
++
++# xindy
++*.xdy
++
++# xypic precompiled matrices
++*.xyc
++
++# endfloat
++*.ttt
++*.fff
++
++# Latexian
++TSWLatexianTemp*
++
++## Editors:
++# WinEdt
++*.bak
++*.sav
++
++# Texpad
++.texpadtmp
++
++# Kile
++*.backup
++
++# KBibTeX
++*~[0-9]*
++
++# auto folder when using emacs and auctex
++./auto/*
++*.el
++
++# expex forward references with \gathertags
++*-tags.tex
++
++# standalone packages
++*.sta
++
++*.directory
+diff --git a/Statusseminar/bib/mybib.bib b/Statusseminar/bib/mybib.bib
+new file mode 100644
+index 0000000..5fa448f
+--- /dev/null
++++ b/Statusseminar/bib/mybib.bib
+@@ -0,0 +1,111 @@
++@BOOKLET{Madsen2010,
++  author = {Lars Madsen},
++  title = {Introduktion til {LaTeX}},
++  year = {2010},
++  howpublished = {\url{http://www.imf.au.dk/system/latex/bog/}}
++ }
++ 
++@MISC{Oetiker2010,
++  author = {Tobias Oetiker},
++  title = {The Not So Short A Introduction to {LaTeX2e}},
++  year = {2010},
++  howpublished = {\url{http://tobi.oetiker.ch/lshort/lshort.pdf}}
++ }
++ 
++@BOOK{Mittelbach2005,
++  author = {Frank Mittelbach},
++  edition = {2. ed.},
++  publisher = {Addison-Wesley},
++  title = {The LATEX companion},
++  year = 2005
++}
++
++@Misc{MatStudieordning,
++	author = {{Aalborg Universitet}},
++	title = {Studieordning for bacheloruddannelsen i matematik},
++	year = {2015},
++}
++
++@BOOK{CLRS2009,
++	author = {Thomas H. Cormen and Charles E. Leiserson and Ronald L. Rivest and Clifford Stein},
++	title = {Introduction to Algorithms},
++	edition = {Third edition},
++	publisher = {MIT Press},
++	year = {2009},
++}
++@BOOK{Rosen2013,
++	author = {Kenneth H. Rosen},
++	title = {Discrete Mathematics and its Applications},
++	edition = {Global edition},
++	year = {2013},
++	publisher = {McGraw-Hill},
++	isbn = {978-9-81467013-5},
++}
++@BOOK{Sebesta2016,
++	author = {Robert W. Sebesta},
++	title = {Concepts of Programming Languages},
++	year = {2016},
++	publisher = {Pearson},
++	edition = {Eleventh edition},
++	isbn = {978-1-292-10055-5},
++}
++@BOOK{Sipser2013,
++	author = {Michael Sipser},
++	title = {Introduction to the Theory of Computation},
++	year = {2013},
++	isbn = {978-1-133-18781-3},
++	edition = {3rd edition},
++}
++@BOOK{Hart2003,
++	author = {Chad Hart},
++	title = {Graph Theory Topics in Computer Networking},
++	year = {2003},
++	howpublished = {\url{http://cms.uhd.edu/faculty/redlt/chadseniorproject.pdf}}
++}
++@BOOK{Chartrand2016,
++	author = {{Chartrand, Lesniak \& Zhang}},
++	title = {Graphs \& Digraphs},
++	year = {2013},
++	edition = {6th edition},
++}
++@ARTICLE{Gansner00,
++	author = {Emden R. Gansner and Stephen C. North},
++	title = {An open graph visualization system and its applications to software engineering},
++	journal = {SOFTWARE - PRACTICE AND EXPERIENCE},
++	year = {2000},
++	volume = {30},
++	number = {11},
++	pages = {1203--1233}
++}
++@Misc{LanguageBenchmark,
++	title = {Language Benchmark},
++	year  = {2017},
++	url   = {http://www.bioinformatics.org/benchmark/results.html},
++	urldate   = {2018-02-20},
++}
++ 
++@Article{North2014, 
++	author = {Stephen C. North and Emden R. Gansner},
++	title = {Cgraph Tutorial},
++	year = {2014},
++	url = {https://graphviz.gitlab.io/_pages/pdf/cgraph.pdf},
++	urldate = {2018-03-06},
++}
++@Misc{Plump2009,
++	title   = {The Graph Programming Language GP},
++	year	= {2009},
++	url     = {https://www.cs.york.ac.uk/plasma/publications/pdf/Plump.CAI.09.pdf},
++	urldate = {2018-02-22},
++}
++@Misc{GP2Issues,
++	title   = {Using 'and' inside 'not' in a Rule Condition causes a build error},
++	year  = {2017},
++	url     = {https://github.com/UoYCS-plasma/GP2/issues/10},
++	urldate = {2018-02-22},
++}
++@Misc{DOTGraphs,
++	title = {Drawing graphs with dot},
++	year  = {2015},
++	url   = {http://www.graphviz.org/pdf/dotguide.pdf},
++	urldate   = {2018-03-02},
++}
+diff --git a/Statusseminar/figures/TikZ/graphs/flownetwork.tex b/Statusseminar/figures/TikZ/graphs/flownetwork.tex
+new file mode 100644
+index 0000000..948917e
+--- /dev/null
++++ b/Statusseminar/figures/TikZ/graphs/flownetwork.tex
+@@ -0,0 +1,26 @@
++\begin{tikzpicture}
++
++\begin{vertices}
++	\node (s) at (0,1.5){s};
++	\node (v1) at (2.5,3){$v_1$};
++	\node (v2) at (2.5,0){$v_2$};
++	\node (v3) at (5,3){$v_3$};
++	\node (v4) at (5,0){$v_4$};
++	\node (t) at (7.5,1.5){t};
++\end{vertices}
++
++\begin{edges}
++	\path[->] (s) edge node[above, xshift=-2mm]{11/16}(v1);
++	\path[->] (s) edge node[below, xshift=-2mm]{8/13}(v2);
++	\path[->] (v1) edge node[above]{12/12}(v3);	
++	\path[->] (v2) edge node[left]{1/4}(v1);
++	\path[->] (v2) edge node[below]{11/14}(v4);
++	\path[->] (v3) edge node[above, xshift=-2mm]{4/9}(v2);
++	\path[->] (v3) edge node[above, xshift=2mm]{15/20}(t);
++	\path[->] (v4) edge node[right]{7/7}(v3);
++	\path[->] (v4) edge node[below]{4/4}(t);
++%	\draw[->] (C) to [out=-90,in=0,looseness=6] (C);
++\end{edges}
++
++
++\end{tikzpicture}
+\ No newline at end of file
+diff --git a/Statusseminar/figures/TikZ/graphs/simple_directed.tex b/Statusseminar/figures/TikZ/graphs/simple_directed.tex
+new file mode 100644
+index 0000000..234b303
+--- /dev/null
++++ b/Statusseminar/figures/TikZ/graphs/simple_directed.tex
+@@ -0,0 +1,17 @@
++\begin{tikzpicture}
++
++\begin{vertices}
++	\node (A) at (0,0){A};
++	\node (B) at (3,0){B};
++	\node (C) at (1.5,2.5){C};
++\end{vertices}
++
++\begin{edges}
++	\path[->] (A) edge[bend right=30] (B);
++	\path[->] (B) edge[bend right=30] (A);
++	\path[->] (A) edge (C);
++	\draw[->] (C) to [out=20,in=-20,looseness=14] (C);
++\end{edges}
++
++
++\end{tikzpicture}
+\ No newline at end of file
+diff --git a/Statusseminar/figures/TikZ/graphs/simple_undirected.tex b/Statusseminar/figures/TikZ/graphs/simple_undirected.tex
+new file mode 100644
+index 0000000..f825063
+--- /dev/null
++++ b/Statusseminar/figures/TikZ/graphs/simple_undirected.tex
+@@ -0,0 +1,17 @@
++\begin{tikzpicture}
++
++\begin{vertices}
++	\node (A) at (0,0){A};
++	\node (B) at (3,0){B};
++	\node (C) at (1.5,2.5){C};
++\end{vertices}
++
++\begin{edges}
++	\path (A) edge (B);
++	\path (A) edge (C);
++%	\draw (C) to [out=135,in=45,looseness=6] (C);
++	\path (B) edge (C);
++	\path[draw=none] (A) edge[bend right=30,draw=none] (B);
++\end{edges}
++
++\end{tikzpicture}
+\ No newline at end of file
+diff --git a/Statusseminar/figures/TikZ/graphs/simple_weighted.tex b/Statusseminar/figures/TikZ/graphs/simple_weighted.tex
+new file mode 100644
+index 0000000..afcd6f0
+--- /dev/null
++++ b/Statusseminar/figures/TikZ/graphs/simple_weighted.tex
+@@ -0,0 +1,17 @@
++\begin{tikzpicture}
++
++\begin{vertices}
++	\node (A) at (0,0){A};
++	\node (B) at (3,0){B};
++	\node (C) at (1.5,2.5){C};
++\end{vertices}
++
++\begin{edges}
++	\path[->] (A) edge[bend right=30] node[above]{2} (B);
++	\path[->] (B) edge[bend right=30] node[above]{4} (A);
++	\path[->] (A) edge node[left]{0.5}(C);
++%	\draw[->] (C) to [out=-90,in=0,looseness=6] (C);
++\end{edges}
++
++
++\end{tikzpicture}
+\ No newline at end of file
+diff --git a/Statusseminar/figures/aau_logo_da.eps b/Statusseminar/figures/aau_logo_da.eps
+new file mode 100644
+index 0000000..c379a21
+--- /dev/null
++++ b/Statusseminar/figures/aau_logo_da.eps
+@@ -0,0 +1,779 @@
++%!PS-Adobe-3.0 EPSF-3.0
++%%BoundingBox: 0 -1 121 76
++%%HiResBoundingBox: 0.000000 -0.049609 120.700000 75.051953
++%.........................................
++%%Creator: GPL Ghostscript 905 (epswrite)
++%%CreationDate: 2013/03/06 22:37:55
++%%DocumentData: Clean7Bit
++%%LanguageLevel: 2
++%%EndComments
++%%BeginProlog
++% This copyright applies to everything between here and the %%EndProlog:
++% Copyright (C) 2010 Artifex Software, Inc.  All rights reserved.
++%%BeginResource: procset GS_epswrite_2_0_1001 1.001 0
++/GS_epswrite_2_0_1001 80 dict dup begin
++/PageSize 2 array def/setpagesize{ PageSize aload pop 3 index eq exch
++4 index eq and{ pop pop pop}{ PageSize dup  1
++5 -1 roll put 0 4 -1 roll put dup null eq {false} {dup where} ifelse{ exch get exec}
++{ pop/setpagedevice where
++{ pop 1 dict dup /PageSize PageSize put setpagedevice}
++{ /setpage where{ pop PageSize aload pop pageparams 3 {exch pop} repeat
++setpage}if}ifelse}ifelse}ifelse} bind def
++/!{bind def}bind def/#{load def}!/N/counttomark #
++/rG{3{3 -1 roll 255 div}repeat setrgbcolor}!/G{255 div setgray}!/K{0 G}!
++/r6{dup 3 -1 roll rG}!/r5{dup 3 1 roll rG}!/r3{dup rG}!
++/w/setlinewidth #/J/setlinecap #
++/j/setlinejoin #/M/setmiterlimit #/d/setdash #/i/setflat #
++/m/moveto #/l/lineto #/c/rcurveto #
++/p{N 2 idiv{N -2 roll rlineto}repeat}!
++/P{N 0 gt{N -2 roll moveto p}if}!
++/h{p closepath}!/H{P closepath}!
++/lx{0 rlineto}!/ly{0 exch rlineto}!/v{0 0 6 2 roll c}!/y{2 copy c}!
++/re{4 -2 roll m exch dup lx exch ly neg lx h}!
++/^{3 index neg 3 index neg}!
++/f{P fill}!/f*{P eofill}!/s{H stroke}!/S{P stroke}!
++/q/gsave #/Q/grestore #/rf{re fill}!
++/Y{P clip newpath}!/Y*{P eoclip newpath}!/rY{re Y}!
++/|={pop exch 4 1 roll 1 array astore cvx 3 array astore cvx exch 1 index def exec}!
++/|{exch string readstring |=}!
++/+{dup type/nametype eq{2 index 7 add -3 bitshift 2 index mul}if}!
++/@/currentfile #/${+ @ |}!
++/B{{2 copy string{readstring pop}aload pop 4 array astore cvx
++3 1 roll}repeat pop pop true}!
++/Ix{[1 0 0 1 11 -2 roll exch neg exch neg]exch}!
++/,{true exch Ix imagemask}!/If{false exch Ix imagemask}!/I{exch Ix image}!
++/Ic{exch Ix false 3 colorimage}!
++/F{/Columns counttomark 3 add -2 roll/Rows exch/K -1/BlackIs1 true>>
++/CCITTFaxDecode filter}!/FX{<</EndOfBlock false F}!
++/X{/ASCII85Decode filter}!/@X{@ X}!/&2{2 index 2 index}!
++/@F{@ &2<<F}!/@C{@X &2 FX}!
++/$X{+ @X |}!/&4{4 index 4 index}!/$F{+ @ &4<<F |}!/$C{+ @X &4 FX |}!
++/IC{3 1 roll 10 dict begin 1{/ImageType/Interpolate/Decode/DataSource
++/ImageMatrix/BitsPerComponent/Height/Width}{exch def}forall
++currentdict end image}!
++/~{@ read {pop} if}!
++end def
++%%EndResource
++/pagesave null def
++%%EndProlog
++%%Page: 1 1
++%%BeginPageSetup
++GS_epswrite_2_0_1001 begin
++/pagesave save store 197 dict begin
++0.1 0.1 scale
++%%EndPageSetup
++gsave mark
++Q q
++0 0 1206.45 750.02 re
++Y
++33 26 82 rG
++33.46 143.03 -5.36 18.02 -0.25 0 -5.61 -18.02 11.22 0 H
++20.03 177.79 m
++0.16 0.51 0.5 0.85 1.1 0.85 c
++13.85 0 p
++0.6 0 0.93 -0.34 1.11 -0.85 c
++19.55 -56.09 p
++0.17 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-14.02 0 p
++-0.59 0 -0.94 0.34 -1.1 0.85 c
++-2.72 8.93 -18.79 0 -2.72 -8.93 p
++-0.17 -0.51 -0.52 -0.85 -1.11 -0.85 c
++-13.94 0 p
++-0.51 0 -0.77 0.34 -0.59 0.85 c
++19.98 56.09 p f
++107.75 143.03 -5.36 18.02 -0.25 0 -5.61 -18.02 11.22 0 H
++94.32 177.79 m
++0.17 0.51 0.51 0.85 1.11 0.85 c
++13.85 0 p
++0.59 0 0.94 -0.34 1.11 -0.85 c
++19.55 -56.09 p
++0.17 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-14.02 0 p
++-0.59 0 -0.94 0.34 -1.1 0.85 c
++-2.72 8.93 -18.78 0 -2.72 -8.93 p
++-0.17 -0.51 -0.51 -0.85 -1.1 -0.85 c
++-13.94 0 p
++-0.51 0 -0.77 0.34 -0.6 0.85 c
++19.98 56.09 p f
++152.46 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -43.17 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++24.48 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -11.56 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-39.1 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++232.01 132.15 6.8 0 P
++4.67 0 7.05 2.3 7.05 6.54 c
++0 4 -2.38 6.46 -7.05 6.46 c
++-6.8 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.99 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++h
++238.05 155.44 m
++4.51 0 6.89 1.96 6.89 5.95 c
++0 4.08 -2.3 5.95 -6.89 5.95 c
++-6.04 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -10.88 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++6.04 0 h
++216.54 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++12.92 0 18.87 -6.2 18.87 -15.38 c
++0 -5.95 -2.72 -10.12 -7.05 -12.41 c
++0 -0.17 p
++4.25 -1.62 8.07 -6.46 8.07 -13.17 c
++0 -11.3 -7.99 -16.66 -20.14 -16.66 c
++-23.29 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++315.14 138.27 m
++0.68 1.96 0.85 4.59 0.85 11.47 c
++0 6.89 -0.17 9.52 -0.85 11.48 c
++-1.02 3.23 -3.66 5.1 -7.39 5.1 c
++-3.74 0 -6.38 -1.87 -7.4 -5.1 c
++-0.68 -1.95 -0.85 -4.59 -0.85 -11.48 c
++0 -6.88 0.17 -9.52 0.85 -11.47 c
++1.02 -3.23 3.66 -5.1 7.4 -5.1 c
++3.73 0 6.37 1.87 7.39 5.1 c
++h
++286.07 134.02 m
++-1.36 4.42 -1.7 7.82 -1.7 15.72 c
++0 7.91 0.34 11.3 1.7 15.72 c
++3.06 9.43 11.48 14.2 21.68 14.2 c
++10.2 0 18.61 -4.76 21.67 -14.2 c
++1.45 -4.42 1.7 -7.82 1.7 -15.72 c
++0 -7.91 -0.25 -11.3 -1.7 -15.72 c
++-3.05 -9.43 -11.47 -14.2 -21.67 -14.2 c
++-10.2 0 -18.61 4.76 -21.68 14.2 c
++f
++386.37 159.86 m
++0 3.74 -2.55 6.12 -6.8 6.12 c
++-7.99 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.21 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++7.99 0 p
++4.25 0 6.8 2.38 6.8 6.12 c
++h
++387.14 120.85 m
++-0.77 0 -1.02 0.25 -1.28 0.85 c
++-8.75 19.72 -5.53 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -19.21 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++13.26 0 20.82 -7.73 20.82 -18.61 c
++0 -7.22 -3.4 -13.09 -9.52 -16.15 c
++10.63 -22.01 p
++0.25 -0.51 0 -1.02 -0.6 -1.02 c
++-14.7 0 p f
++424.8 149.75 m
++0 7.91 0.34 11.3 1.7 15.72 c
++3.06 9.43 11.48 14.2 21.76 14.2 c
++10.63 0 17.76 -4.93 20.99 -12.32 c
++0.26 -0.6 0.09 -1.11 -0.43 -1.36 c
++-11.05 -4.68 p
++-0.51 -0.25 -1.02 -0.08 -1.28 0.34 c
++-1.95 3.15 -4.25 4.68 -8.24 4.68 c
++-3.91 0 -6.46 -1.87 -7.48 -5.1 c
++-0.68 -2.04 -0.85 -4.59 -0.85 -11.48 c
++0 -6.88 0.25 -9.52 0.85 -11.47 c
++1.11 -3.23 3.74 -5.1 7.91 -5.1 c
++3.74 0 6.71 1.62 7.65 4.59 c
++0.34 1.02 0.51 2.21 0.51 3.74 c
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-6.29 0 p
++-0.51 0 -0.86 0.34 -0.86 0.85 c
++0 9.6 p
++0 0.52 0.34 0.85 0.86 0.85 c
++20.65 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -4.42 p
++0 -5.52 -0.34 -9.86 -1.53 -13.43 c
++-3.06 -9.61 -11.22 -14.79 -21.76 -14.79 c
++-10.29 0 -18.7 4.76 -21.76 14.2 c
++-1.36 4.42 -1.7 7.82 -1.7 15.72 c
++f
++533.6 143.2 0 34.59 P
++0 0.51 0.34 0.85 0.85 0.85 c
++13.25 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -35.53 p
++0 -5.78 3.23 -9.09 8.08 -9.09 c
++5.01 0 7.98 3.31 7.98 9.09 c
++0 35.53 p
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -34.59 p
++0 -15.39 -9.18 -23.37 -22.94 -23.37 c
++-14.03 0 -23.04 7.99 -23.04 23.38 c
++f
++605.76 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++12.5 0 p
++0.59 0 1.19 -0.25 1.45 -0.85 c
++17.42 -32.72 0.34 0 0 32.72 p
++0 0.51 0.34 0.85 0.85 0.85 c
++11.9 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-12.5 0 p
++-0.59 0 -1.19 0.25 -1.45 0.85 c
++-17.25 32.64 -0.51 0 0 -32.64 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-11.9 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++678.26 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++735.21 120.85 m
++-0.6 0 -0.93 0.25 -1.11 0.85 c
++-18.44 56.01 p
++-0.17 0.51 0.16 0.93 0.76 0.93 c
++13.94 0 p
++0.59 0 0.93 -0.25 1.1 -0.85 c
++10.29 -34.84 0.26 0 9.94 34.84 p
++0.17 0.6 0.51 0.85 1.11 0.85 c
++13.86 0 p
++0.59 0 0.85 -0.43 0.68 -0.93 c
++-18.45 -56.01 p
++-0.17 -0.59 -0.51 -0.85 -1.11 -0.85 c
++-12.83 0 p f
++790.04 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++37.82 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-23.2 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -8.75 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++19.04 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-19.04 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.52 c
++0 -9.26 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++23.2 0 p
++0.51 0 0.85 -0.34 0.85 -0.86 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-37.82 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++884.64 159.86 m
++0 3.74 -2.55 6.12 -6.8 6.12 c
++-7.99 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.21 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++7.99 0 p
++4.25 0 6.8 2.38 6.8 6.12 c
++h
++885.41 120.85 m
++-0.77 0 -1.02 0.25 -1.27 0.85 c
++-8.76 19.72 -5.53 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -19.21 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++13.26 0 20.82 -7.73 20.82 -18.61 c
++0 -7.22 -3.4 -13.09 -9.52 -16.15 c
++10.63 -22.01 p
++0.25 -0.51 0 -1.02 -0.6 -1.02 c
++-14.7 0 p f
++922.38 128.08 m
++-0.43 0.34 -0.51 0.93 -0.09 1.36 c
++7.65 9.01 p
++0.34 0.43 0.85 0.43 1.19 0.09 c
++3.48 -3.06 8.93 -5.78 14.71 -5.78 c
++5.35 0 8.16 2.21 8.16 5.44 c
++0 2.47 -1.62 4.08 -7.31 4.84 c
++-3.06 0.43 p
++-12.5 1.79 -19.29 7.39 -19.29 18.19 c
++0 10.8 8.41 18.02 21.5 18.02 c
++7.99 0 15.47 -2.46 20.65 -6.37 c
++0.43 -0.34 0.52 -0.77 0.17 -1.28 c
++-6.37 -9.27 p
++-0.34 -0.43 -0.77 -0.51 -1.19 -0.25 c
++-4.08 2.72 -8.41 4.34 -13 4.34 c
++-4.25 0 -6.37 -2.04 -6.37 -4.84 c
++0 -2.55 1.87 -4.16 7.39 -4.85 c
++3.06 -0.43 p
++12.66 -1.78 19.13 -7.39 19.13 -18.36 c
++0 -10.71 -8.16 -18.53 -23.63 -18.53 c
++-9.43 0 -18.95 4 -23.29 8.25 c
++f
++993.27 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++1047.33 120.85 -0.25 0 P
++-0.18 0 -0.26 0.08 -0.43 0.25 c
++-0.08 0.09 -0.17 0.17 -0.17 0.34 c
++0 43.43 p
++0 0.26 -0.17 0.42 -0.43 0.51 c
++-14.53 0 p
++-0.17 0 -0.25 0.08 -0.34 0.17 c
++-0.08 0.08 p
++0 0.09 -0.09 0.09 v
++-0.08 0.17 -0.08 0.34 -0.08 0.51 c
++0 11.56 p
++0 0.43 0.25 0.77 0.59 0.85 c
++44.62 0 p
++0.26 0 0.43 -0.09 0.6 -0.25 c
++0.08 -0.09 0.08 -0.17 v
++0.09 -0.08 0.17 -0.25 0.17 -0.43 c
++0 -11.56 p
++0 -0.25 -0.08 -0.51 -0.25 -0.68 c
++-0.09 -0.09 -0.26 -0.17 -0.43 -0.17 c
++-14.36 0 p
++-0.17 0 -0.26 0 -0.34 -0.09 c
++-0.09 0 -0.09 -0.08 -0.17 -0.16 c
++0 -43.69 p
++-0.09 -0.25 -0.17 -0.34 -0.42 -0.51 c
++-0.09 -0.08 -0.26 -0.08 -0.43 -0.08 c
++-13.26 0 p f
++1099.69 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++37.82 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-23.2 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -8.75 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++19.03 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -10.71 p
++0 -0.51 -0.33 -0.85 -0.85 -0.85 c
++-19.03 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.52 c
++0 -9.26 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++23.2 0 p
++0.51 0 0.85 -0.34 0.85 -0.86 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-37.82 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++1176.78 120.85 -0.25 0 P
++-0.17 0 -0.26 0.08 -0.43 0.25 c
++-0.08 0.09 -0.17 0.17 -0.17 0.34 c
++0 43.43 p
++0 0.26 -0.17 0.42 -0.42 0.51 c
++-14.53 0 p
++-0.17 0 -0.26 0.08 -0.35 0.17 c
++-0.08 0.08 p
++0 0.09 -0.09 0.09 v
++-0.08 0.17 -0.08 0.34 -0.08 0.51 c
++0 11.56 p
++0 0.43 0.25 0.77 0.6 0.85 c
++44.62 0 p
++0.25 0 0.42 -0.09 0.59 -0.25 c
++0.08 -0.09 0.08 -0.17 v
++0.09 -0.08 0.18 -0.25 0.18 -0.43 c
++0 -11.56 p
++0 -0.25 -0.09 -0.51 -0.26 -0.68 c
++-0.09 -0.09 -0.25 -0.17 -0.42 -0.17 c
++-14.37 0 p
++-0.17 0 -0.25 0 -0.34 -0.09 c
++-0.08 0 -0.08 -0.08 -0.17 -0.16 c
++0 -43.69 p
++-0.08 -0.25 -0.17 -0.34 -0.42 -0.51 c
++-0.09 -0.08 -0.26 -0.08 -0.43 -0.08 c
++-13.26 0 p f
++82.12 6.71 m
++-0.34 0.34 -0.42 0.85 -0.08 1.19 c
++2.04 2.55 p
++0.34 0.42 0.85 0.42 1.19 0.08 c
++3.83 -2.98 9.86 -5.95 16.57 -5.95 c
++9.27 0 14.96 4.67 14.96 11.81 c
++0 5.7 -3.23 9.86 -13.85 11.22 c
++-2.64 0.34 p
++-11.3 1.45 -16.66 6.88 -16.66 15.3 c
++0 10.03 7.14 16.23 18.19 16.23 c
++6.38 0 12.49 -1.95 16.48 -4.84 c
++0.43 -0.25 0.52 -0.77 0.17 -1.19 c
++-1.7 -2.63 p
++-0.34 -0.42 -0.76 -0.42 -1.19 -0.17 c
++-4.59 2.8 -9.09 4.25 -14.02 4.25 c
++-8.24 0 -13.09 -4.59 -13.09 -11.3 c
++0 -5.86 3.74 -9.69 13.6 -10.96 c
++2.63 -0.34 p
++11.73 -1.53 16.91 -6.97 16.91 -15.55 c
++0 -9.77 -6.97 -16.74 -20.39 -16.74 c
++-7.57 0 -15.13 3.23 -19.13 6.71 c
++f
++163.98 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-16.66 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++217.1 20.74 m
++0 -10.88 5.53 -16.15 14.71 -16.15 c
++9.26 0 14.79 5.27 14.79 16.15 c
++0 37.05 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -36.97 p
++0 -14.11 -7.65 -20.82 -19.63 -20.82 c
++-11.9 0 -19.55 6.71 -19.55 20.82 c
++0 36.97 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -37.05 p f
++289.18 5.44 12.92 0 P
++7.47 0 12.41 2.64 14.45 8.75 c
++0.93 2.8 1.36 5.78 1.36 15.55 c
++0 9.78 -0.43 12.75 -1.36 15.55 c
++-2.04 6.13 -6.97 8.76 -14.45 8.76 c
++-12.92 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -47.6 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++h
++283.82 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++18.11 0 p
++9.61 0 15.89 -3.82 18.45 -11.73 c
++1.1 -3.4 1.61 -6.62 1.61 -17.17 c
++0 -10.54 -0.51 -13.77 -1.61 -17.17 c
++-2.55 -7.91 -8.84 -11.73 -18.45 -11.73 c
++-18.11 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++353.52 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++33.06 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-28.55 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -20.57 p
++0 -0.34 0.17 -0.52 0.52 -0.52 c
++24.56 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-24.56 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -21.42 p
++0 -0.34 0.17 -0.51 0.52 -0.51 c
++28.55 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-33.06 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++417.78 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.59 0 1.11 -0.17 1.45 -0.85 c
++28.81 -47.51 0.25 0 0 47.51 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.32 0 p
++-0.51 0 -1.02 0.17 -1.45 0.85 c
++-28.55 47.6 -0.34 0 0 -47.6 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++502.87 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-16.66 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++551.74 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++33.06 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-28.55 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -20.57 p
++0 -0.34 0.17 -0.52 0.52 -0.52 c
++24.56 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-24.56 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -21.42 p
++0 -0.34 0.17 -0.51 0.52 -0.51 c
++28.55 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-33.06 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++648.98 42.67 m
++0 7.22 -4.59 11.39 -12.84 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.25 0 12.84 4.08 12.84 11.39 c
++h
++650.25 0.85 m
++-0.51 0 -0.77 0.17 -1.02 0.77 c
++-12.16 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.59 -6.12 17.59 -15.98 c
++0 -7.99 -4.42 -13.52 -11.81 -15.3 c
++12.58 -25.59 p
++0.34 -0.51 0.08 -0.93 -0.43 -0.93 c
++-3.91 0 p f
++718.25 42.67 m
++0 7.22 -4.59 11.39 -12.84 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.25 0 12.84 4.08 12.84 11.39 c
++h
++719.53 0.85 m
++-0.51 0 -0.77 0.17 -1.02 0.77 c
++-12.16 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.15 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.59 -6.12 17.59 -15.98 c
++0 -7.99 -4.42 -13.52 -11.82 -15.3 c
++12.59 -25.59 p
++0.34 -0.51 0.08 -0.93 -0.43 -0.93 c
++-3.91 0 p f
++782.85 20.57 -10.79 30.26 -0.25 0 -10.88 -30.26 21.92 0 H
++769.43 57.79 m
++0.17 0.51 0.51 0.85 1.02 0.85 c
++3.06 0 p
++0.59 0 0.85 -0.34 1.02 -0.85 c
++20.06 -56.09 p
++0.16 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-3.31 0 p
++-0.6 0 -0.94 0.17 -1.11 0.85 c
++-5.1 14.2 -25.16 0 -5.1 -14.2 p
++-0.26 -0.68 -0.6 -0.85 -1.11 -0.85 c
++-3.32 0 p
++-0.51 0 -0.76 0.34 -0.59 0.85 c
++20.23 56.09 p f
++855.27 42.24 m
++0 7.39 -4.59 11.81 -13.09 11.81 c
++-14.62 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -22.53 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++14.62 0 p
++8.5 0 13.09 4.34 13.09 11.73 c
++h
++823.06 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.29 0 p
++11.05 0 17.77 -6.29 17.77 -16.4 c
++0 -10.12 -6.71 -16.32 -17.77 -16.32 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -23.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++922 42.24 m
++0 7.39 -4.59 11.81 -13.09 11.81 c
++-14.62 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -22.53 p
++0 -0.34 0.17 -0.51 0.52 -0.51 c
++14.62 0 p
++8.5 0 13.09 4.34 13.09 11.73 c
++h
++889.79 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.29 0 p
++11.05 0 17.76 -6.29 17.76 -16.4 c
++0 -10.12 -6.71 -16.32 -17.76 -16.32 c
++-14.79 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -23.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++987.54 45.13 m
++-2.13 6.37 -6.8 9.77 -13.94 9.77 c
++-7.23 0 -11.9 -3.4 -14.02 -9.77 c
++-0.77 -2.3 -1.45 -6.04 -1.45 -15.39 c
++0 -9.35 0.68 -13.09 1.45 -15.38 c
++2.13 -6.38 6.8 -9.78 14.02 -9.78 c
++7.14 0 11.81 3.4 13.94 9.78 c
++0.76 2.29 1.44 6.03 1.44 15.38 c
++0 9.35 -0.68 13.09 -1.44 15.39 c
++h
++954.9 13 m
++-1.02 3.06 -1.71 6.8 -1.71 16.74 c
++0 9.95 0.69 13.69 1.71 16.74 c
++2.8 8.5 9.26 13 18.7 13 c
++9.35 0 15.8 -4.5 18.61 -13 c
++1.02 -3.05 1.7 -6.8 1.7 -16.74 c
++0 -9.94 -0.68 -13.68 -1.7 -16.74 c
++-2.81 -8.5 -9.26 -13 -18.61 -13 c
++-9.43 0 -15.89 4.5 -18.7 13 c
++f
++1057.4 42.67 m
++0 7.22 -4.59 11.39 -12.83 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.24 0 12.83 4.08 12.83 11.39 c
++h
++1058.68 0.85 m
++-0.52 0 -0.77 0.17 -1.02 0.77 c
++-12.16 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.15 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.35 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.6 -6.12 17.6 -15.98 c
++0 -7.99 -4.42 -13.52 -11.82 -15.3 c
++12.58 -25.59 p
++0.34 -0.51 0.09 -0.93 -0.42 -0.93 c
++-3.91 0 p f
++1106.02 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.35 0.85 0.85 0.85 c
++39.18 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.33 -0.85 -0.85 -0.85 c
++-16.65 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -51.85 p
++0 -0.51 -0.33 -0.85 -0.84 -0.85 c
++-3.15 0 p f
++770.92 426.54 m
++-10.71 4.8 -21.89 8.79 -40.09 19.88 c
++-51.16 31.19 -66.71 77.61 -37.95 158.58 c
++16.64 46.89 24.64 86.43 20.53 129.09 c
++-0.58 0.38 -1.17 0.75 -1.75 1.13 c
++-2.68 -53.57 -22.43 -86.88 -57.81 -143.26 c
++-74.96 -119.45 1.14 -206.99 37.3 -234.22 c
++31.89 16.07 59.27 39.8 79.77 68.8 c
++f
++619.12 596.32 m
++57.8 68.03 76.59 99.39 80.49 146.2 c
++-0.62 0.34 -1.23 0.73 -1.85 1.07 c
++-13.39 -56.01 -46.97 -85.69 -135.46 -144.63 c
++-95.32 -63.47 -91.04 -172.59 -66.77 -240.51 c
++29.57 -15.17 63.02 -23.79 98.52 -23.79 c
++7.56 0 15.03 0.4 22.41 1.16 c
++-68.82 104.42 -64.05 181.96 2.67 260.49 c
++f
++583.79 646.52 m
++63.83 27.7 94.1 69.77 102.85 102.71 c
++-0.55 0.27 -1.14 0.52 -1.7 0.78 c
++-27.79 -58.13 -83.26 -67.83 -178.1 -80.54 c
++-56.23 -7.54 -99.97 -39.76 -126.37 -79.64 c
++-2.1 -12.17 -3.27 -24.68 -3.27 -37.46 c
++0 -51.83 18.07 -99.39 48.18 -136.77 c
++-2.68 162.79 81.88 197.73 158.41 230.92 c
++f
++cleartomark end end pagesave restore
++ showpage
++%%PageTrailer
++%%Trailer
++%%Pages: 1
+diff --git a/Statusseminar/figures/aau_logo_da.eps~ b/Statusseminar/figures/aau_logo_da.eps~
+new file mode 100644
+index 0000000..89da6b2
+--- /dev/null
++++ b/Statusseminar/figures/aau_logo_da.eps~
+@@ -0,0 +1,779 @@
++%!PS-Adobe-3.0 EPSF-3.0
++%%BoundingBox: 0 -1 121 76
++%%HiResBoundingBox: 0.000000 -0.049609 120.700000 75.051953
++%.........................................
++%%Creator: GPL Ghostscript 905 (epswrite)
++%%CreationDate: 2013/03/06 22:37:55
++%%DocumentData: Clean7Bit
++%%LanguageLevel: 2
++%%EndComments
++%%BeginProlog
++% This copyright applies to everything between here and the %%EndProlog:
++% Copyright (C) 2010 Artifex Software, Inc.  All rights reserved.
++%%BeginResource: procset GS_epswrite_2_0_1001 1.001 0
++/GS_epswrite_2_0_1001 80 dict dup begin
++/PageSize 2 array def/setpagesize{ PageSize aload pop 3 index eq exch
++4 index eq and{ pop pop pop}{ PageSize dup  1
++5 -1 roll put 0 4 -1 roll put dup null eq {false} {dup where} ifelse{ exch get exec}
++{ pop/setpagedevice where
++{ pop 1 dict dup /PageSize PageSize put setpagedevice}
++{ /setpage where{ pop PageSize aload pop pageparams 3 {exch pop} repeat
++setpage}if}ifelse}ifelse}ifelse} bind def
++/!{bind def}bind def/#{load def}!/N/counttomark #
++/rG{3{3 -1 roll 255 div}repeat setrgbcolor}!/G{255 div setgray}!/K{0 G}!
++/r6{dup 3 -1 roll rG}!/r5{dup 3 1 roll rG}!/r3{dup rG}!
++/w/setlinewidth #/J/setlinecap #
++/j/setlinejoin #/M/setmiterlimit #/d/setdash #/i/setflat #
++/m/moveto #/l/lineto #/c/rcurveto #
++/p{N 2 idiv{N -2 roll rlineto}repeat}!
++/P{N 0 gt{N -2 roll moveto p}if}!
++/h{p closepath}!/H{P closepath}!
++/lx{0 rlineto}!/ly{0 exch rlineto}!/v{0 0 6 2 roll c}!/y{2 copy c}!
++/re{4 -2 roll m exch dup lx exch ly neg lx h}!
++/^{3 index neg 3 index neg}!
++/f{P fill}!/f*{P eofill}!/s{H stroke}!/S{P stroke}!
++/q/gsave #/Q/grestore #/rf{re fill}!
++/Y{P clip newpath}!/Y*{P eoclip newpath}!/rY{re Y}!
++/|={pop exch 4 1 roll 1 array astore cvx 3 array astore cvx exch 1 index def exec}!
++/|{exch string readstring |=}!
++/+{dup type/nametype eq{2 index 7 add -3 bitshift 2 index mul}if}!
++/@/currentfile #/${+ @ |}!
++/B{{2 copy string{readstring pop}aload pop 4 array astore cvx
++3 1 roll}repeat pop pop true}!
++/Ix{[1 0 0 1 11 -2 roll exch neg exch neg]exch}!
++/,{true exch Ix imagemask}!/If{false exch Ix imagemask}!/I{exch Ix image}!
++/Ic{exch Ix false 3 colorimage}!
++/F{/Columns counttomark 3 add -2 roll/Rows exch/K -1/BlackIs1 true>>
++/CCITTFaxDecode filter}!/FX{<</EndOfBlock false F}!
++/X{/ASCII85Decode filter}!/@X{@ X}!/&2{2 index 2 index}!
++/@F{@ &2<<F}!/@C{@X &2 FX}!
++/$X{+ @X |}!/&4{4 index 4 index}!/$F{+ @ &4<<F |}!/$C{+ @X &4 FX |}!
++/IC{3 1 roll 10 dict begin 1{/ImageType/Interpolate/Decode/DataSource
++/ImageMatrix/BitsPerComponent/Height/Width}{exch def}forall
++currentdict end image}!
++/~{@ read {pop} if}!
++end def
++%%EndResource
++/pagesave null def
++%%EndProlog
++%%Page: 1 1
++%%BeginPageSetup
++GS_epswrite_2_0_1001 begin
++/pagesave save store 197 dict begin
++0.1 0.1 scale
++%%EndPageSetup
++gsave mark
++Q q
++0 0 1206.45 750.02 re
++Y
++0 36 87 rG
++33.46 143.03 -5.36 18.02 -0.25 0 -5.61 -18.02 11.22 0 H
++20.03 177.79 m
++0.16 0.51 0.5 0.85 1.1 0.85 c
++13.85 0 p
++0.6 0 0.93 -0.34 1.11 -0.85 c
++19.55 -56.09 p
++0.17 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-14.02 0 p
++-0.59 0 -0.94 0.34 -1.1 0.85 c
++-2.72 8.93 -18.79 0 -2.72 -8.93 p
++-0.17 -0.51 -0.52 -0.85 -1.11 -0.85 c
++-13.94 0 p
++-0.51 0 -0.77 0.34 -0.59 0.85 c
++19.98 56.09 p f
++107.75 143.03 -5.36 18.02 -0.25 0 -5.61 -18.02 11.22 0 H
++94.32 177.79 m
++0.17 0.51 0.51 0.85 1.11 0.85 c
++13.85 0 p
++0.59 0 0.94 -0.34 1.11 -0.85 c
++19.55 -56.09 p
++0.17 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-14.02 0 p
++-0.59 0 -0.94 0.34 -1.1 0.85 c
++-2.72 8.93 -18.78 0 -2.72 -8.93 p
++-0.17 -0.51 -0.51 -0.85 -1.1 -0.85 c
++-13.94 0 p
++-0.51 0 -0.77 0.34 -0.6 0.85 c
++19.98 56.09 p f
++152.46 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -43.17 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++24.48 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -11.56 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-39.1 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++232.01 132.15 6.8 0 P
++4.67 0 7.05 2.3 7.05 6.54 c
++0 4 -2.38 6.46 -7.05 6.46 c
++-6.8 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.99 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++h
++238.05 155.44 m
++4.51 0 6.89 1.96 6.89 5.95 c
++0 4.08 -2.3 5.95 -6.89 5.95 c
++-6.04 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -10.88 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++6.04 0 h
++216.54 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++12.92 0 18.87 -6.2 18.87 -15.38 c
++0 -5.95 -2.72 -10.12 -7.05 -12.41 c
++0 -0.17 p
++4.25 -1.62 8.07 -6.46 8.07 -13.17 c
++0 -11.3 -7.99 -16.66 -20.14 -16.66 c
++-23.29 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++315.14 138.27 m
++0.68 1.96 0.85 4.59 0.85 11.47 c
++0 6.89 -0.17 9.52 -0.85 11.48 c
++-1.02 3.23 -3.66 5.1 -7.39 5.1 c
++-3.74 0 -6.38 -1.87 -7.4 -5.1 c
++-0.68 -1.95 -0.85 -4.59 -0.85 -11.48 c
++0 -6.88 0.17 -9.52 0.85 -11.47 c
++1.02 -3.23 3.66 -5.1 7.4 -5.1 c
++3.73 0 6.37 1.87 7.39 5.1 c
++h
++286.07 134.02 m
++-1.36 4.42 -1.7 7.82 -1.7 15.72 c
++0 7.91 0.34 11.3 1.7 15.72 c
++3.06 9.43 11.48 14.2 21.68 14.2 c
++10.2 0 18.61 -4.76 21.67 -14.2 c
++1.45 -4.42 1.7 -7.82 1.7 -15.72 c
++0 -7.91 -0.25 -11.3 -1.7 -15.72 c
++-3.05 -9.43 -11.47 -14.2 -21.67 -14.2 c
++-10.2 0 -18.61 4.76 -21.68 14.2 c
++f
++386.37 159.86 m
++0 3.74 -2.55 6.12 -6.8 6.12 c
++-7.99 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.21 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++7.99 0 p
++4.25 0 6.8 2.38 6.8 6.12 c
++h
++387.14 120.85 m
++-0.77 0 -1.02 0.25 -1.28 0.85 c
++-8.75 19.72 -5.53 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -19.21 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++13.26 0 20.82 -7.73 20.82 -18.61 c
++0 -7.22 -3.4 -13.09 -9.52 -16.15 c
++10.63 -22.01 p
++0.25 -0.51 0 -1.02 -0.6 -1.02 c
++-14.7 0 p f
++424.8 149.75 m
++0 7.91 0.34 11.3 1.7 15.72 c
++3.06 9.43 11.48 14.2 21.76 14.2 c
++10.63 0 17.76 -4.93 20.99 -12.32 c
++0.26 -0.6 0.09 -1.11 -0.43 -1.36 c
++-11.05 -4.68 p
++-0.51 -0.25 -1.02 -0.08 -1.28 0.34 c
++-1.95 3.15 -4.25 4.68 -8.24 4.68 c
++-3.91 0 -6.46 -1.87 -7.48 -5.1 c
++-0.68 -2.04 -0.85 -4.59 -0.85 -11.48 c
++0 -6.88 0.25 -9.52 0.85 -11.47 c
++1.11 -3.23 3.74 -5.1 7.91 -5.1 c
++3.74 0 6.71 1.62 7.65 4.59 c
++0.34 1.02 0.51 2.21 0.51 3.74 c
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-6.29 0 p
++-0.51 0 -0.86 0.34 -0.86 0.85 c
++0 9.6 p
++0 0.52 0.34 0.85 0.86 0.85 c
++20.65 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -4.42 p
++0 -5.52 -0.34 -9.86 -1.53 -13.43 c
++-3.06 -9.61 -11.22 -14.79 -21.76 -14.79 c
++-10.29 0 -18.7 4.76 -21.76 14.2 c
++-1.36 4.42 -1.7 7.82 -1.7 15.72 c
++f
++533.6 143.2 0 34.59 P
++0 0.51 0.34 0.85 0.85 0.85 c
++13.25 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -35.53 p
++0 -5.78 3.23 -9.09 8.08 -9.09 c
++5.01 0 7.98 3.31 7.98 9.09 c
++0 35.53 p
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -34.59 p
++0 -15.39 -9.18 -23.37 -22.94 -23.37 c
++-14.03 0 -23.04 7.99 -23.04 23.38 c
++f
++605.76 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++12.5 0 p
++0.59 0 1.19 -0.25 1.45 -0.85 c
++17.42 -32.72 0.34 0 0 32.72 p
++0 0.51 0.34 0.85 0.85 0.85 c
++11.9 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-12.5 0 p
++-0.59 0 -1.19 0.25 -1.45 0.85 c
++-17.25 32.64 -0.51 0 0 -32.64 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-11.9 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++678.26 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++735.21 120.85 m
++-0.6 0 -0.93 0.25 -1.11 0.85 c
++-18.44 56.01 p
++-0.17 0.51 0.16 0.93 0.76 0.93 c
++13.94 0 p
++0.59 0 0.93 -0.25 1.1 -0.85 c
++10.29 -34.84 0.26 0 9.94 34.84 p
++0.17 0.6 0.51 0.85 1.11 0.85 c
++13.86 0 p
++0.59 0 0.85 -0.43 0.68 -0.93 c
++-18.45 -56.01 p
++-0.17 -0.59 -0.51 -0.85 -1.11 -0.85 c
++-12.83 0 p f
++790.04 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++37.82 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-23.2 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -8.75 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++19.04 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-19.04 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.52 c
++0 -9.26 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++23.2 0 p
++0.51 0 0.85 -0.34 0.85 -0.86 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-37.82 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++884.64 159.86 m
++0 3.74 -2.55 6.12 -6.8 6.12 c
++-7.99 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.21 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++7.99 0 p
++4.25 0 6.8 2.38 6.8 6.12 c
++h
++885.41 120.85 m
++-0.77 0 -1.02 0.25 -1.27 0.85 c
++-8.76 19.72 -5.53 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -19.21 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++13.26 0 20.82 -7.73 20.82 -18.61 c
++0 -7.22 -3.4 -13.09 -9.52 -16.15 c
++10.63 -22.01 p
++0.25 -0.51 0 -1.02 -0.6 -1.02 c
++-14.7 0 p f
++922.38 128.08 m
++-0.43 0.34 -0.51 0.93 -0.09 1.36 c
++7.65 9.01 p
++0.34 0.43 0.85 0.43 1.19 0.09 c
++3.48 -3.06 8.93 -5.78 14.71 -5.78 c
++5.35 0 8.16 2.21 8.16 5.44 c
++0 2.47 -1.62 4.08 -7.31 4.84 c
++-3.06 0.43 p
++-12.5 1.79 -19.29 7.39 -19.29 18.19 c
++0 10.8 8.41 18.02 21.5 18.02 c
++7.99 0 15.47 -2.46 20.65 -6.37 c
++0.43 -0.34 0.52 -0.77 0.17 -1.28 c
++-6.37 -9.27 p
++-0.34 -0.43 -0.77 -0.51 -1.19 -0.25 c
++-4.08 2.72 -8.41 4.34 -13 4.34 c
++-4.25 0 -6.37 -2.04 -6.37 -4.84 c
++0 -2.55 1.87 -4.16 7.39 -4.85 c
++3.06 -0.43 p
++12.66 -1.78 19.13 -7.39 19.13 -18.36 c
++0 -10.71 -8.16 -18.53 -23.63 -18.53 c
++-9.43 0 -18.95 4 -23.29 8.25 c
++f
++993.27 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++1047.33 120.85 -0.25 0 P
++-0.18 0 -0.26 0.08 -0.43 0.25 c
++-0.08 0.09 -0.17 0.17 -0.17 0.34 c
++0 43.43 p
++0 0.26 -0.17 0.42 -0.43 0.51 c
++-14.53 0 p
++-0.17 0 -0.25 0.08 -0.34 0.17 c
++-0.08 0.08 p
++0 0.09 -0.09 0.09 v
++-0.08 0.17 -0.08 0.34 -0.08 0.51 c
++0 11.56 p
++0 0.43 0.25 0.77 0.59 0.85 c
++44.62 0 p
++0.26 0 0.43 -0.09 0.6 -0.25 c
++0.08 -0.09 0.08 -0.17 v
++0.09 -0.08 0.17 -0.25 0.17 -0.43 c
++0 -11.56 p
++0 -0.25 -0.08 -0.51 -0.25 -0.68 c
++-0.09 -0.09 -0.26 -0.17 -0.43 -0.17 c
++-14.36 0 p
++-0.17 0 -0.26 0 -0.34 -0.09 c
++-0.09 0 -0.09 -0.08 -0.17 -0.16 c
++0 -43.69 p
++-0.09 -0.25 -0.17 -0.34 -0.42 -0.51 c
++-0.09 -0.08 -0.26 -0.08 -0.43 -0.08 c
++-13.26 0 p f
++1099.69 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++37.82 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-23.2 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -8.75 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++19.03 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -10.71 p
++0 -0.51 -0.33 -0.85 -0.85 -0.85 c
++-19.03 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.52 c
++0 -9.26 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++23.2 0 p
++0.51 0 0.85 -0.34 0.85 -0.86 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-37.82 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++1176.78 120.85 -0.25 0 P
++-0.17 0 -0.26 0.08 -0.43 0.25 c
++-0.08 0.09 -0.17 0.17 -0.17 0.34 c
++0 43.43 p
++0 0.26 -0.17 0.42 -0.42 0.51 c
++-14.53 0 p
++-0.17 0 -0.26 0.08 -0.35 0.17 c
++-0.08 0.08 p
++0 0.09 -0.09 0.09 v
++-0.08 0.17 -0.08 0.34 -0.08 0.51 c
++0 11.56 p
++0 0.43 0.25 0.77 0.6 0.85 c
++44.62 0 p
++0.25 0 0.42 -0.09 0.59 -0.25 c
++0.08 -0.09 0.08 -0.17 v
++0.09 -0.08 0.18 -0.25 0.18 -0.43 c
++0 -11.56 p
++0 -0.25 -0.09 -0.51 -0.26 -0.68 c
++-0.09 -0.09 -0.25 -0.17 -0.42 -0.17 c
++-14.37 0 p
++-0.17 0 -0.25 0 -0.34 -0.09 c
++-0.08 0 -0.08 -0.08 -0.17 -0.16 c
++0 -43.69 p
++-0.08 -0.25 -0.17 -0.34 -0.42 -0.51 c
++-0.09 -0.08 -0.26 -0.08 -0.43 -0.08 c
++-13.26 0 p f
++82.12 6.71 m
++-0.34 0.34 -0.42 0.85 -0.08 1.19 c
++2.04 2.55 p
++0.34 0.42 0.85 0.42 1.19 0.08 c
++3.83 -2.98 9.86 -5.95 16.57 -5.95 c
++9.27 0 14.96 4.67 14.96 11.81 c
++0 5.7 -3.23 9.86 -13.85 11.22 c
++-2.64 0.34 p
++-11.3 1.45 -16.66 6.88 -16.66 15.3 c
++0 10.03 7.14 16.23 18.19 16.23 c
++6.38 0 12.49 -1.95 16.48 -4.84 c
++0.43 -0.25 0.52 -0.77 0.17 -1.19 c
++-1.7 -2.63 p
++-0.34 -0.42 -0.76 -0.42 -1.19 -0.17 c
++-4.59 2.8 -9.09 4.25 -14.02 4.25 c
++-8.24 0 -13.09 -4.59 -13.09 -11.3 c
++0 -5.86 3.74 -9.69 13.6 -10.96 c
++2.63 -0.34 p
++11.73 -1.53 16.91 -6.97 16.91 -15.55 c
++0 -9.77 -6.97 -16.74 -20.39 -16.74 c
++-7.57 0 -15.13 3.23 -19.13 6.71 c
++f
++163.98 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-16.66 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++217.1 20.74 m
++0 -10.88 5.53 -16.15 14.71 -16.15 c
++9.26 0 14.79 5.27 14.79 16.15 c
++0 37.05 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -36.97 p
++0 -14.11 -7.65 -20.82 -19.63 -20.82 c
++-11.9 0 -19.55 6.71 -19.55 20.82 c
++0 36.97 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -37.05 p f
++289.18 5.44 12.92 0 P
++7.47 0 12.41 2.64 14.45 8.75 c
++0.93 2.8 1.36 5.78 1.36 15.55 c
++0 9.78 -0.43 12.75 -1.36 15.55 c
++-2.04 6.13 -6.97 8.76 -14.45 8.76 c
++-12.92 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -47.6 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++h
++283.82 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++18.11 0 p
++9.61 0 15.89 -3.82 18.45 -11.73 c
++1.1 -3.4 1.61 -6.62 1.61 -17.17 c
++0 -10.54 -0.51 -13.77 -1.61 -17.17 c
++-2.55 -7.91 -8.84 -11.73 -18.45 -11.73 c
++-18.11 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++353.52 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++33.06 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-28.55 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -20.57 p
++0 -0.34 0.17 -0.52 0.52 -0.52 c
++24.56 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-24.56 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -21.42 p
++0 -0.34 0.17 -0.51 0.52 -0.51 c
++28.55 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-33.06 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++417.78 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.59 0 1.11 -0.17 1.45 -0.85 c
++28.81 -47.51 0.25 0 0 47.51 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.32 0 p
++-0.51 0 -1.02 0.17 -1.45 0.85 c
++-28.55 47.6 -0.34 0 0 -47.6 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++502.87 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-16.66 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++551.74 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++33.06 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-28.55 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -20.57 p
++0 -0.34 0.17 -0.52 0.52 -0.52 c
++24.56 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-24.56 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -21.42 p
++0 -0.34 0.17 -0.51 0.52 -0.51 c
++28.55 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-33.06 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++648.98 42.67 m
++0 7.22 -4.59 11.39 -12.84 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.25 0 12.84 4.08 12.84 11.39 c
++h
++650.25 0.85 m
++-0.51 0 -0.77 0.17 -1.02 0.77 c
++-12.16 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.59 -6.12 17.59 -15.98 c
++0 -7.99 -4.42 -13.52 -11.81 -15.3 c
++12.58 -25.59 p
++0.34 -0.51 0.08 -0.93 -0.43 -0.93 c
++-3.91 0 p f
++718.25 42.67 m
++0 7.22 -4.59 11.39 -12.84 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.25 0 12.84 4.08 12.84 11.39 c
++h
++719.53 0.85 m
++-0.51 0 -0.77 0.17 -1.02 0.77 c
++-12.16 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.15 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.59 -6.12 17.59 -15.98 c
++0 -7.99 -4.42 -13.52 -11.82 -15.3 c
++12.59 -25.59 p
++0.34 -0.51 0.08 -0.93 -0.43 -0.93 c
++-3.91 0 p f
++782.85 20.57 -10.79 30.26 -0.25 0 -10.88 -30.26 21.92 0 H
++769.43 57.79 m
++0.17 0.51 0.51 0.85 1.02 0.85 c
++3.06 0 p
++0.59 0 0.85 -0.34 1.02 -0.85 c
++20.06 -56.09 p
++0.16 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-3.31 0 p
++-0.6 0 -0.94 0.17 -1.11 0.85 c
++-5.1 14.2 -25.16 0 -5.1 -14.2 p
++-0.26 -0.68 -0.6 -0.85 -1.11 -0.85 c
++-3.32 0 p
++-0.51 0 -0.76 0.34 -0.59 0.85 c
++20.23 56.09 p f
++855.27 42.24 m
++0 7.39 -4.59 11.81 -13.09 11.81 c
++-14.62 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -22.53 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++14.62 0 p
++8.5 0 13.09 4.34 13.09 11.73 c
++h
++823.06 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.29 0 p
++11.05 0 17.77 -6.29 17.77 -16.4 c
++0 -10.12 -6.71 -16.32 -17.77 -16.32 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -23.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++922 42.24 m
++0 7.39 -4.59 11.81 -13.09 11.81 c
++-14.62 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -22.53 p
++0 -0.34 0.17 -0.51 0.52 -0.51 c
++14.62 0 p
++8.5 0 13.09 4.34 13.09 11.73 c
++h
++889.79 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.29 0 p
++11.05 0 17.76 -6.29 17.76 -16.4 c
++0 -10.12 -6.71 -16.32 -17.76 -16.32 c
++-14.79 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -23.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++987.54 45.13 m
++-2.13 6.37 -6.8 9.77 -13.94 9.77 c
++-7.23 0 -11.9 -3.4 -14.02 -9.77 c
++-0.77 -2.3 -1.45 -6.04 -1.45 -15.39 c
++0 -9.35 0.68 -13.09 1.45 -15.38 c
++2.13 -6.38 6.8 -9.78 14.02 -9.78 c
++7.14 0 11.81 3.4 13.94 9.78 c
++0.76 2.29 1.44 6.03 1.44 15.38 c
++0 9.35 -0.68 13.09 -1.44 15.39 c
++h
++954.9 13 m
++-1.02 3.06 -1.71 6.8 -1.71 16.74 c
++0 9.95 0.69 13.69 1.71 16.74 c
++2.8 8.5 9.26 13 18.7 13 c
++9.35 0 15.8 -4.5 18.61 -13 c
++1.02 -3.05 1.7 -6.8 1.7 -16.74 c
++0 -9.94 -0.68 -13.68 -1.7 -16.74 c
++-2.81 -8.5 -9.26 -13 -18.61 -13 c
++-9.43 0 -15.89 4.5 -18.7 13 c
++f
++1057.4 42.67 m
++0 7.22 -4.59 11.39 -12.83 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.24 0 12.83 4.08 12.83 11.39 c
++h
++1058.68 0.85 m
++-0.52 0 -0.77 0.17 -1.02 0.77 c
++-12.16 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.15 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.35 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.6 -6.12 17.6 -15.98 c
++0 -7.99 -4.42 -13.52 -11.82 -15.3 c
++12.58 -25.59 p
++0.34 -0.51 0.09 -0.93 -0.42 -0.93 c
++-3.91 0 p f
++1106.02 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.35 0.85 0.85 0.85 c
++39.18 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.33 -0.85 -0.85 -0.85 c
++-16.65 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -51.85 p
++0 -0.51 -0.33 -0.85 -0.84 -0.85 c
++-3.15 0 p f
++770.92 426.54 m
++-10.71 4.8 -21.89 8.79 -40.09 19.88 c
++-51.16 31.19 -66.71 77.61 -37.95 158.58 c
++16.64 46.89 24.64 86.43 20.53 129.09 c
++-0.58 0.38 -1.17 0.75 -1.75 1.13 c
++-2.68 -53.57 -22.43 -86.88 -57.81 -143.26 c
++-74.96 -119.45 1.14 -206.99 37.3 -234.22 c
++31.89 16.07 59.27 39.8 79.77 68.8 c
++f
++619.12 596.32 m
++57.8 68.03 76.59 99.39 80.49 146.2 c
++-0.62 0.34 -1.23 0.73 -1.85 1.07 c
++-13.39 -56.01 -46.97 -85.69 -135.46 -144.63 c
++-95.32 -63.47 -91.04 -172.59 -66.77 -240.51 c
++29.57 -15.17 63.02 -23.79 98.52 -23.79 c
++7.56 0 15.03 0.4 22.41 1.16 c
++-68.82 104.42 -64.05 181.96 2.67 260.49 c
++f
++583.79 646.52 m
++63.83 27.7 94.1 69.77 102.85 102.71 c
++-0.55 0.27 -1.14 0.52 -1.7 0.78 c
++-27.79 -58.13 -83.26 -67.83 -178.1 -80.54 c
++-56.23 -7.54 -99.97 -39.76 -126.37 -79.64 c
++-2.1 -12.17 -3.27 -24.68 -3.27 -37.46 c
++0 -51.83 18.07 -99.39 48.18 -136.77 c
++-2.68 162.79 81.88 197.73 158.41 230.92 c
++f
++cleartomark end end pagesave restore
++ showpage
++%%PageTrailer
++%%Trailer
++%%Pages: 1
+diff --git a/Statusseminar/figures/aau_logo_en.eps b/Statusseminar/figures/aau_logo_en.eps
+new file mode 100644
+index 0000000..b3be02a
+--- /dev/null
++++ b/Statusseminar/figures/aau_logo_en.eps
+@@ -0,0 +1,681 @@
++%!PS-Adobe-3.0 EPSF-3.0
++%%BoundingBox: 0 -1 115 76
++%%HiResBoundingBox: 0.000000 -0.049609 114.600000 75.051953
++%.........................................
++%%Creator: GPL Ghostscript 905 (epswrite)
++%%CreationDate: 2013/03/06 22:36:39
++%%DocumentData: Clean7Bit
++%%LanguageLevel: 2
++%%EndComments
++%%BeginProlog
++% This copyright applies to everything between here and the %%EndProlog:
++% Copyright (C) 2010 Artifex Software, Inc.  All rights reserved.
++%%BeginResource: procset GS_epswrite_2_0_1001 1.001 0
++/GS_epswrite_2_0_1001 80 dict dup begin
++/PageSize 2 array def/setpagesize{ PageSize aload pop 3 index eq exch
++4 index eq and{ pop pop pop}{ PageSize dup  1
++5 -1 roll put 0 4 -1 roll put dup null eq {false} {dup where} ifelse{ exch get exec}
++{ pop/setpagedevice where
++{ pop 1 dict dup /PageSize PageSize put setpagedevice}
++{ /setpage where{ pop PageSize aload pop pageparams 3 {exch pop} repeat
++setpage}if}ifelse}ifelse}ifelse} bind def
++/!{bind def}bind def/#{load def}!/N/counttomark #
++/rG{3{3 -1 roll 255 div}repeat setrgbcolor}!/G{255 div setgray}!/K{0 G}!
++/r6{dup 3 -1 roll rG}!/r5{dup 3 1 roll rG}!/r3{dup rG}!
++/w/setlinewidth #/J/setlinecap #
++/j/setlinejoin #/M/setmiterlimit #/d/setdash #/i/setflat #
++/m/moveto #/l/lineto #/c/rcurveto #
++/p{N 2 idiv{N -2 roll rlineto}repeat}!
++/P{N 0 gt{N -2 roll moveto p}if}!
++/h{p closepath}!/H{P closepath}!
++/lx{0 rlineto}!/ly{0 exch rlineto}!/v{0 0 6 2 roll c}!/y{2 copy c}!
++/re{4 -2 roll m exch dup lx exch ly neg lx h}!
++/^{3 index neg 3 index neg}!
++/f{P fill}!/f*{P eofill}!/s{H stroke}!/S{P stroke}!
++/q/gsave #/Q/grestore #/rf{re fill}!
++/Y{P clip newpath}!/Y*{P eoclip newpath}!/rY{re Y}!
++/|={pop exch 4 1 roll 1 array astore cvx 3 array astore cvx exch 1 index def exec}!
++/|{exch string readstring |=}!
++/+{dup type/nametype eq{2 index 7 add -3 bitshift 2 index mul}if}!
++/@/currentfile #/${+ @ |}!
++/B{{2 copy string{readstring pop}aload pop 4 array astore cvx
++3 1 roll}repeat pop pop true}!
++/Ix{[1 0 0 1 11 -2 roll exch neg exch neg]exch}!
++/,{true exch Ix imagemask}!/If{false exch Ix imagemask}!/I{exch Ix image}!
++/Ic{exch Ix false 3 colorimage}!
++/F{/Columns counttomark 3 add -2 roll/Rows exch/K -1/BlackIs1 true>>
++/CCITTFaxDecode filter}!/FX{<</EndOfBlock false F}!
++/X{/ASCII85Decode filter}!/@X{@ X}!/&2{2 index 2 index}!
++/@F{@ &2<<F}!/@C{@X &2 FX}!
++/$X{+ @X |}!/&4{4 index 4 index}!/$F{+ @ &4<<F |}!/$C{+ @X &4 FX |}!
++/IC{3 1 roll 10 dict begin 1{/ImageType/Interpolate/Decode/DataSource
++/ImageMatrix/BitsPerComponent/Height/Width}{exch def}forall
++currentdict end image}!
++/~{@ read {pop} if}!
++end def
++%%EndResource
++/pagesave null def
++%%EndProlog
++%%Page: 1 1
++%%BeginPageSetup
++GS_epswrite_2_0_1001 begin
++/pagesave save store 197 dict begin
++0.1 0.1 scale
++%%EndPageSetup
++gsave mark
++Q q
++0 0 1145.65 750.02 re
++Y
++33 26 82 rG
++33.46 143.03 -5.36 18.02 -0.25 0 -5.61 -18.02 11.22 0 H
++20.03 177.79 m
++0.16 0.51 0.5 0.85 1.1 0.85 c
++13.85 0 p
++0.6 0 0.94 -0.34 1.11 -0.85 c
++19.55 -56.09 p
++0.17 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-14.02 0 p
++-0.59 0 -0.94 0.34 -1.1 0.85 c
++-2.72 8.93 -18.79 0 -2.72 -8.93 p
++-0.17 -0.51 -0.52 -0.85 -1.11 -0.85 c
++-13.94 0 p
++-0.51 0 -0.77 0.34 -0.59 0.85 c
++19.98 56.09 p f
++107.75 143.03 -5.36 18.02 -0.25 0 -5.61 -18.02 11.22 0 H
++94.32 177.79 m
++0.17 0.51 0.51 0.85 1.11 0.85 c
++13.85 0 p
++0.59 0 0.93 -0.34 1.11 -0.85 c
++19.55 -56.09 p
++0.17 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-14.02 0 p
++-0.59 0 -0.94 0.34 -1.1 0.85 c
++-2.72 8.93 -18.78 0 -2.72 -8.93 p
++-0.17 -0.51 -0.51 -0.85 -1.1 -0.85 c
++-13.94 0 p
++-0.51 0 -0.77 0.34 -0.6 0.85 c
++19.98 56.09 p f
++152.46 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -43.17 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++24.48 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -11.56 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-39.1 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++232.01 132.15 6.8 0 P
++4.67 0 7.05 2.3 7.05 6.54 c
++0 4 -2.38 6.46 -7.05 6.46 c
++-6.8 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.99 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++h
++238.05 155.44 m
++4.51 0 6.89 1.96 6.89 5.95 c
++0 4.08 -2.3 5.95 -6.89 5.95 c
++-6.04 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -10.88 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++6.04 0 h
++216.54 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++12.92 0 18.87 -6.2 18.87 -15.38 c
++0 -5.95 -2.72 -10.12 -7.05 -12.41 c
++0 -0.17 p
++4.25 -1.62 8.07 -6.46 8.07 -13.17 c
++0 -11.3 -7.99 -16.66 -20.14 -16.66 c
++-23.29 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++315.14 138.27 m
++0.68 1.96 0.85 4.59 0.85 11.47 c
++0 6.89 -0.17 9.52 -0.85 11.48 c
++-1.02 3.23 -3.66 5.1 -7.39 5.1 c
++-3.74 0 -6.38 -1.87 -7.4 -5.1 c
++-0.68 -1.95 -0.85 -4.59 -0.85 -11.48 c
++0 -6.88 0.17 -9.52 0.85 -11.47 c
++1.02 -3.23 3.66 -5.1 7.4 -5.1 c
++3.73 0 6.37 1.87 7.39 5.1 c
++h
++286.07 134.02 m
++-1.36 4.42 -1.7 7.82 -1.7 15.72 c
++0 7.91 0.34 11.3 1.7 15.72 c
++3.06 9.43 11.48 14.2 21.68 14.2 c
++10.2 0 18.61 -4.76 21.67 -14.2 c
++1.45 -4.42 1.7 -7.82 1.7 -15.72 c
++0 -7.91 -0.25 -11.3 -1.7 -15.72 c
++-3.05 -9.43 -11.47 -14.2 -21.67 -14.2 c
++-10.2 0 -18.61 4.76 -21.68 14.2 c
++f
++386.37 159.86 m
++0 3.74 -2.55 6.12 -6.8 6.12 c
++-7.99 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.21 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++7.99 0 p
++4.25 0 6.8 2.38 6.8 6.12 c
++h
++387.14 120.85 m
++-0.77 0 -1.02 0.25 -1.28 0.85 c
++-8.75 19.72 -5.53 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -19.21 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++13.26 0 20.82 -7.73 20.82 -18.61 c
++0 -7.22 -3.4 -13.09 -9.52 -16.15 c
++10.63 -22.01 p
++0.25 -0.51 0 -1.02 -0.6 -1.02 c
++-14.7 0 p f
++424.8 149.75 m
++0 7.91 0.34 11.3 1.7 15.72 c
++3.06 9.43 11.48 14.2 21.76 14.2 c
++10.63 0 17.76 -4.93 20.99 -12.32 c
++0.26 -0.6 0.09 -1.11 -0.43 -1.36 c
++-11.05 -4.68 p
++-0.51 -0.25 -1.02 -0.08 -1.28 0.34 c
++-1.95 3.15 -4.25 4.68 -8.24 4.68 c
++-3.91 0 -6.46 -1.87 -7.48 -5.1 c
++-0.68 -2.04 -0.85 -4.59 -0.85 -11.48 c
++0 -6.88 0.25 -9.52 0.85 -11.47 c
++1.11 -3.23 3.74 -5.1 7.91 -5.1 c
++3.74 0 6.71 1.62 7.65 4.59 c
++0.34 1.02 0.51 2.21 0.51 3.74 c
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-6.29 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 9.6 p
++0 0.52 0.34 0.85 0.85 0.85 c
++20.65 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -4.42 p
++0 -5.52 -0.34 -9.86 -1.53 -13.43 c
++-3.06 -9.61 -11.22 -14.79 -21.76 -14.79 c
++-10.29 0 -18.7 4.76 -21.76 14.2 c
++-1.36 4.42 -1.7 7.82 -1.7 15.72 c
++f
++533.6 143.2 0 34.59 P
++0 0.51 0.34 0.85 0.85 0.85 c
++13.25 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -35.53 p
++0 -5.78 3.23 -9.09 8.08 -9.09 c
++5.01 0 7.98 3.31 7.98 9.09 c
++0 35.53 p
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -34.59 p
++0 -15.39 -9.18 -23.37 -22.94 -23.37 c
++-14.03 0 -23.04 7.99 -23.04 23.38 c
++f
++605.76 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++12.5 0 p
++0.59 0 1.19 -0.25 1.45 -0.85 c
++17.42 -32.72 0.34 0 0 32.72 p
++0 0.51 0.34 0.85 0.85 0.85 c
++11.9 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-12.5 0 p
++-0.59 0 -1.19 0.25 -1.45 0.85 c
++-17.25 32.64 -0.51 0 0 -32.64 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-11.9 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++678.26 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++735.21 120.85 m
++-0.6 0 -0.93 0.25 -1.11 0.85 c
++-18.44 56.01 p
++-0.17 0.51 0.16 0.93 0.76 0.93 c
++13.94 0 p
++0.59 0 0.93 -0.25 1.1 -0.85 c
++10.29 -34.84 0.26 0 9.94 34.84 p
++0.17 0.6 0.51 0.85 1.11 0.85 c
++13.86 0 p
++0.59 0 0.85 -0.43 0.68 -0.93 c
++-18.45 -56.01 p
++-0.17 -0.59 -0.51 -0.85 -1.11 -0.85 c
++-12.83 0 p f
++790.04 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++37.82 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-23.2 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -8.75 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++19.04 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-19.04 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.52 c
++0 -9.26 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++23.2 0 p
++0.51 0 0.85 -0.34 0.85 -0.86 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-37.82 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++884.64 159.86 m
++0 3.74 -2.55 6.12 -6.8 6.12 c
++-7.99 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.21 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++7.99 0 p
++4.25 0 6.8 2.38 6.8 6.12 c
++h
++885.41 120.85 m
++-0.77 0 -1.02 0.25 -1.27 0.85 c
++-8.76 19.72 -5.53 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -19.21 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++13.26 0 20.82 -7.73 20.82 -18.61 c
++0 -7.22 -3.4 -13.09 -9.52 -16.15 c
++10.63 -22.01 p
++0.25 -0.51 0 -1.02 -0.6 -1.02 c
++-14.7 0 p f
++922.38 128.08 m
++-0.43 0.34 -0.51 0.93 -0.09 1.36 c
++7.65 9.01 p
++0.34 0.43 0.85 0.43 1.19 0.09 c
++3.48 -3.06 8.93 -5.78 14.71 -5.78 c
++5.35 0 8.16 2.21 8.16 5.44 c
++0 2.47 -1.62 4.08 -7.31 4.84 c
++-3.06 0.43 p
++-12.5 1.79 -19.29 7.39 -19.29 18.19 c
++0 10.8 8.41 18.02 21.5 18.02 c
++7.99 0 15.47 -2.46 20.65 -6.37 c
++0.43 -0.34 0.52 -0.77 0.17 -1.28 c
++-6.37 -9.27 p
++-0.34 -0.43 -0.77 -0.51 -1.19 -0.25 c
++-4.08 2.72 -8.41 4.34 -13 4.34 c
++-4.25 0 -6.37 -2.04 -6.37 -4.84 c
++0 -2.55 1.87 -4.16 7.39 -4.85 c
++3.06 -0.43 p
++12.66 -1.78 19.13 -7.39 19.13 -18.36 c
++0 -10.71 -8.16 -18.53 -23.63 -18.53 c
++-9.43 0 -18.95 4 -23.29 8.25 c
++f
++993.27 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++1047.33 120.85 -0.25 0 P
++-0.18 0 -0.26 0.08 -0.43 0.25 c
++-0.08 0.09 -0.17 0.17 -0.17 0.34 c
++0 43.43 p
++0 0.26 -0.17 0.42 -0.43 0.51 c
++-14.53 0 p
++-0.17 0 -0.26 0.08 -0.34 0.17 c
++-0.08 0.08 p
++0 0.09 -0.09 0.09 v
++-0.08 0.17 -0.08 0.34 -0.08 0.51 c
++0 11.56 p
++0 0.43 0.25 0.77 0.59 0.85 c
++44.62 0 p
++0.26 0 0.43 -0.09 0.6 -0.25 c
++0.08 -0.09 0.08 -0.17 v
++0.09 -0.08 0.17 -0.25 0.17 -0.43 c
++0 -11.56 p
++0 -0.25 -0.08 -0.51 -0.25 -0.68 c
++-0.09 -0.09 -0.26 -0.17 -0.43 -0.17 c
++-14.36 0 p
++-0.17 0 -0.26 0 -0.34 -0.09 c
++-0.09 0 -0.09 -0.08 -0.17 -0.16 c
++0 -43.69 p
++-0.09 -0.25 -0.17 -0.34 -0.42 -0.51 c
++-0.09 -0.08 -0.26 -0.08 -0.43 -0.08 c
++-13.26 0 p f
++1113.97 120.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 21.5 -17.51 34.51 p
++-0.17 0.51 0.08 0.93 0.68 0.93 c
++13.34 0 p
++0.6 0 1.02 -0.25 1.36 -0.85 c
++9.69 -19.71 0.26 0 9.51 19.71 p
++0.26 0.6 0.77 0.85 1.37 0.85 c
++13.08 0 p
++0.69 0 0.86 -0.43 0.69 -0.93 c
++-17.51 -34.51 0 -21.5 p
++0 -0.51 -0.35 -0.85 -0.85 -0.85 c
++-13.26 0 p f
++134.06 6.71 m
++-0.34 0.34 -0.43 0.85 -0.08 1.19 c
++2.04 2.55 p
++0.34 0.42 0.85 0.42 1.19 0.08 c
++3.83 -2.98 9.86 -5.95 16.57 -5.95 c
++9.27 0 14.96 4.67 14.96 11.81 c
++0 5.7 -3.23 9.86 -13.85 11.22 c
++-2.64 0.34 p
++-11.3 1.45 -16.66 6.88 -16.66 15.3 c
++0 10.03 7.14 16.23 18.19 16.23 c
++6.38 0 12.49 -1.95 16.49 -4.84 c
++0.42 -0.25 0.51 -0.77 0.17 -1.19 c
++-1.7 -2.63 p
++-0.34 -0.42 -0.76 -0.42 -1.19 -0.17 c
++-4.58 2.8 -9.09 4.25 -14.02 4.25 c
++-8.24 0 -13.09 -4.59 -13.09 -11.3 c
++0 -5.86 3.74 -9.69 13.6 -10.96 c
++2.63 -0.34 p
++11.73 -1.53 16.91 -6.97 16.91 -15.55 c
++0 -9.77 -6.97 -16.74 -20.39 -16.74 c
++-7.56 0 -15.13 3.23 -19.12 6.71 c
++f
++215.91 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-16.65 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++269.04 20.74 m
++0 -10.88 5.53 -16.15 14.71 -16.15 c
++9.26 0 14.79 5.27 14.79 16.15 c
++0 37.05 p
++0 0.51 0.34 0.85 0.86 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -36.97 p
++0 -14.11 -7.65 -20.82 -19.63 -20.82 c
++-11.9 0 -19.55 6.71 -19.55 20.82 c
++0 36.97 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -37.05 p f
++341.12 5.44 12.92 0 P
++7.48 0 12.41 2.64 14.45 8.75 c
++0.93 2.8 1.36 5.78 1.36 15.55 c
++0 9.78 -0.43 12.75 -1.36 15.55 c
++-2.04 6.13 -6.97 8.76 -14.45 8.76 c
++-12.92 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -47.6 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++h
++335.76 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++18.11 0 p
++9.6 0 15.89 -3.82 18.44 -11.73 c
++1.1 -3.4 1.61 -6.62 1.61 -17.17 c
++0 -10.54 -0.51 -13.77 -1.61 -17.17 c
++-2.55 -7.91 -8.84 -11.73 -18.44 -11.73 c
++-18.11 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++405.46 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++33.06 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-28.55 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -20.57 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++24.56 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-24.56 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.42 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++28.55 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-33.06 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++469.72 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.6 0 1.11 -0.17 1.45 -0.85 c
++28.82 -47.51 0.25 0 0 47.51 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.32 0 p
++-0.51 0 -1.02 0.17 -1.45 0.85 c
++-28.55 47.6 -0.34 0 0 -47.6 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++554.8 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-16.66 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++673.71 42.67 m
++0 7.22 -4.59 11.39 -12.84 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.25 0 12.84 4.08 12.84 11.39 c
++h
++674.99 0.85 m
++-0.51 0 -0.77 0.17 -1.02 0.77 c
++-12.15 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.59 -6.12 17.59 -15.98 c
++0 -7.99 -4.42 -13.52 -11.82 -15.3 c
++12.58 -25.59 p
++0.34 -0.51 0.09 -0.93 -0.42 -0.93 c
++-3.91 0 p f
++710.02 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++33.06 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-28.55 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -20.57 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++24.56 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-24.56 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.42 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++28.55 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-33.06 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++807.34 42.24 m
++0 7.39 -4.59 11.81 -13.09 11.81 c
++-14.62 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -22.53 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++14.62 0 p
++8.5 0 13.09 4.34 13.09 11.73 c
++h
++775.12 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.29 0 p
++11.05 0 17.77 -6.29 17.77 -16.4 c
++0 -10.12 -6.71 -16.32 -17.77 -16.32 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -23.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++872.87 45.13 m
++-2.13 6.37 -6.8 9.77 -13.94 9.77 c
++-7.23 0 -11.9 -3.4 -14.02 -9.77 c
++-0.77 -2.3 -1.45 -6.04 -1.45 -15.39 c
++0 -9.35 0.68 -13.09 1.45 -15.38 c
++2.13 -6.38 6.8 -9.78 14.02 -9.78 c
++7.14 0 11.81 3.4 13.94 9.78 c
++0.76 2.29 1.44 6.03 1.44 15.38 c
++0 9.35 -0.68 13.09 -1.44 15.39 c
++h
++840.23 13 m
++-1.02 3.06 -1.7 6.8 -1.7 16.74 c
++0 9.95 0.68 13.69 1.7 16.74 c
++2.8 8.5 9.26 13 18.7 13 c
++9.35 0 15.8 -4.5 18.61 -13 c
++1.02 -3.05 1.7 -6.8 1.7 -16.74 c
++0 -9.94 -0.68 -13.68 -1.7 -16.74 c
++-2.81 -8.5 -9.26 -13 -18.61 -13 c
++-9.43 0 -15.89 4.5 -18.7 13 c
++f
++942.74 42.67 m
++0 7.22 -4.59 11.39 -12.84 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.25 0 12.84 4.08 12.84 11.39 c
++h
++944.02 0.85 m
++-0.52 0 -0.77 0.17 -1.02 0.77 c
++-12.15 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.59 -6.12 17.59 -15.98 c
++0 -7.99 -4.42 -13.52 -11.82 -15.3 c
++12.59 -25.59 p
++0.34 -0.51 0.08 -0.93 -0.43 -0.93 c
++-3.91 0 p f
++991.36 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.33 -0.85 -0.85 -0.85 c
++-16.65 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++739.55 426.54 m
++-10.71 4.8 -21.88 8.79 -40.09 19.88 c
++-51.16 31.19 -66.71 77.61 -37.95 158.58 c
++16.64 46.89 24.64 86.43 20.53 129.09 c
++-0.58 0.38 -1.17 0.75 -1.75 1.13 c
++-2.68 -53.57 -22.43 -86.88 -57.81 -143.26 c
++-74.96 -119.45 1.14 -206.99 37.3 -234.22 c
++31.89 16.07 59.27 39.8 79.77 68.8 c
++f
++587.75 596.32 m
++57.8 68.03 76.59 99.39 80.49 146.2 c
++-0.62 0.34 -1.23 0.73 -1.85 1.07 c
++-13.39 -56.01 -46.97 -85.69 -135.46 -144.63 c
++-95.32 -63.47 -91.04 -172.59 -66.77 -240.51 c
++29.57 -15.17 63.02 -23.79 98.52 -23.79 c
++7.56 0 15.04 0.4 22.41 1.16 c
++-68.82 104.42 -64.05 181.96 2.67 260.49 c
++f
++552.43 646.52 m
++63.84 27.7 94.1 69.77 102.85 102.71 c
++-0.55 0.27 -1.14 0.52 -1.7 0.78 c
++-27.79 -58.13 -83.26 -67.83 -178.1 -80.54 c
++-56.23 -7.54 -99.97 -39.76 -126.37 -79.64 c
++-2.1 -12.17 -3.27 -24.68 -3.27 -37.46 c
++0 -51.83 18.07 -99.39 48.18 -136.77 c
++-2.68 162.79 81.88 197.73 158.41 230.92 c
++f
++cleartomark end end pagesave restore
++ showpage
++%%PageTrailer
++%%Trailer
++%%Pages: 1
+diff --git a/Statusseminar/figures/aau_logo_en.eps~ b/Statusseminar/figures/aau_logo_en.eps~
+new file mode 100644
+index 0000000..a06a816
+--- /dev/null
++++ b/Statusseminar/figures/aau_logo_en.eps~
+@@ -0,0 +1,681 @@
++%!PS-Adobe-3.0 EPSF-3.0
++%%BoundingBox: 0 -1 115 76
++%%HiResBoundingBox: 0.000000 -0.049609 114.600000 75.051953
++%.........................................
++%%Creator: GPL Ghostscript 905 (epswrite)
++%%CreationDate: 2013/03/06 22:36:39
++%%DocumentData: Clean7Bit
++%%LanguageLevel: 2
++%%EndComments
++%%BeginProlog
++% This copyright applies to everything between here and the %%EndProlog:
++% Copyright (C) 2010 Artifex Software, Inc.  All rights reserved.
++%%BeginResource: procset GS_epswrite_2_0_1001 1.001 0
++/GS_epswrite_2_0_1001 80 dict dup begin
++/PageSize 2 array def/setpagesize{ PageSize aload pop 3 index eq exch
++4 index eq and{ pop pop pop}{ PageSize dup  1
++5 -1 roll put 0 4 -1 roll put dup null eq {false} {dup where} ifelse{ exch get exec}
++{ pop/setpagedevice where
++{ pop 1 dict dup /PageSize PageSize put setpagedevice}
++{ /setpage where{ pop PageSize aload pop pageparams 3 {exch pop} repeat
++setpage}if}ifelse}ifelse}ifelse} bind def
++/!{bind def}bind def/#{load def}!/N/counttomark #
++/rG{3{3 -1 roll 255 div}repeat setrgbcolor}!/G{255 div setgray}!/K{0 G}!
++/r6{dup 3 -1 roll rG}!/r5{dup 3 1 roll rG}!/r3{dup rG}!
++/w/setlinewidth #/J/setlinecap #
++/j/setlinejoin #/M/setmiterlimit #/d/setdash #/i/setflat #
++/m/moveto #/l/lineto #/c/rcurveto #
++/p{N 2 idiv{N -2 roll rlineto}repeat}!
++/P{N 0 gt{N -2 roll moveto p}if}!
++/h{p closepath}!/H{P closepath}!
++/lx{0 rlineto}!/ly{0 exch rlineto}!/v{0 0 6 2 roll c}!/y{2 copy c}!
++/re{4 -2 roll m exch dup lx exch ly neg lx h}!
++/^{3 index neg 3 index neg}!
++/f{P fill}!/f*{P eofill}!/s{H stroke}!/S{P stroke}!
++/q/gsave #/Q/grestore #/rf{re fill}!
++/Y{P clip newpath}!/Y*{P eoclip newpath}!/rY{re Y}!
++/|={pop exch 4 1 roll 1 array astore cvx 3 array astore cvx exch 1 index def exec}!
++/|{exch string readstring |=}!
++/+{dup type/nametype eq{2 index 7 add -3 bitshift 2 index mul}if}!
++/@/currentfile #/${+ @ |}!
++/B{{2 copy string{readstring pop}aload pop 4 array astore cvx
++3 1 roll}repeat pop pop true}!
++/Ix{[1 0 0 1 11 -2 roll exch neg exch neg]exch}!
++/,{true exch Ix imagemask}!/If{false exch Ix imagemask}!/I{exch Ix image}!
++/Ic{exch Ix false 3 colorimage}!
++/F{/Columns counttomark 3 add -2 roll/Rows exch/K -1/BlackIs1 true>>
++/CCITTFaxDecode filter}!/FX{<</EndOfBlock false F}!
++/X{/ASCII85Decode filter}!/@X{@ X}!/&2{2 index 2 index}!
++/@F{@ &2<<F}!/@C{@X &2 FX}!
++/$X{+ @X |}!/&4{4 index 4 index}!/$F{+ @ &4<<F |}!/$C{+ @X &4 FX |}!
++/IC{3 1 roll 10 dict begin 1{/ImageType/Interpolate/Decode/DataSource
++/ImageMatrix/BitsPerComponent/Height/Width}{exch def}forall
++currentdict end image}!
++/~{@ read {pop} if}!
++end def
++%%EndResource
++/pagesave null def
++%%EndProlog
++%%Page: 1 1
++%%BeginPageSetup
++GS_epswrite_2_0_1001 begin
++/pagesave save store 197 dict begin
++0.1 0.1 scale
++%%EndPageSetup
++gsave mark
++Q q
++0 0 1145.65 750.02 re
++Y
++0 36 87 rG
++33.46 143.03 -5.36 18.02 -0.25 0 -5.61 -18.02 11.22 0 H
++20.03 177.79 m
++0.16 0.51 0.5 0.85 1.1 0.85 c
++13.85 0 p
++0.6 0 0.94 -0.34 1.11 -0.85 c
++19.55 -56.09 p
++0.17 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-14.02 0 p
++-0.59 0 -0.94 0.34 -1.1 0.85 c
++-2.72 8.93 -18.79 0 -2.72 -8.93 p
++-0.17 -0.51 -0.52 -0.85 -1.11 -0.85 c
++-13.94 0 p
++-0.51 0 -0.77 0.34 -0.59 0.85 c
++19.98 56.09 p f
++107.75 143.03 -5.36 18.02 -0.25 0 -5.61 -18.02 11.22 0 H
++94.32 177.79 m
++0.17 0.51 0.51 0.85 1.11 0.85 c
++13.85 0 p
++0.59 0 0.93 -0.34 1.11 -0.85 c
++19.55 -56.09 p
++0.17 -0.51 -0.09 -0.85 -0.6 -0.85 c
++-14.02 0 p
++-0.59 0 -0.94 0.34 -1.1 0.85 c
++-2.72 8.93 -18.78 0 -2.72 -8.93 p
++-0.17 -0.51 -0.51 -0.85 -1.1 -0.85 c
++-13.94 0 p
++-0.51 0 -0.77 0.34 -0.6 0.85 c
++19.98 56.09 p f
++152.46 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -43.17 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++24.48 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -11.56 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-39.1 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++232.01 132.15 6.8 0 P
++4.67 0 7.05 2.3 7.05 6.54 c
++0 4 -2.38 6.46 -7.05 6.46 c
++-6.8 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.99 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++h
++238.05 155.44 m
++4.51 0 6.89 1.96 6.89 5.95 c
++0 4.08 -2.3 5.95 -6.89 5.95 c
++-6.04 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -10.88 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++6.04 0 h
++216.54 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++12.92 0 18.87 -6.2 18.87 -15.38 c
++0 -5.95 -2.72 -10.12 -7.05 -12.41 c
++0 -0.17 p
++4.25 -1.62 8.07 -6.46 8.07 -13.17 c
++0 -11.3 -7.99 -16.66 -20.14 -16.66 c
++-23.29 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++315.14 138.27 m
++0.68 1.96 0.85 4.59 0.85 11.47 c
++0 6.89 -0.17 9.52 -0.85 11.48 c
++-1.02 3.23 -3.66 5.1 -7.39 5.1 c
++-3.74 0 -6.38 -1.87 -7.4 -5.1 c
++-0.68 -1.95 -0.85 -4.59 -0.85 -11.48 c
++0 -6.88 0.17 -9.52 0.85 -11.47 c
++1.02 -3.23 3.66 -5.1 7.4 -5.1 c
++3.73 0 6.37 1.87 7.39 5.1 c
++h
++286.07 134.02 m
++-1.36 4.42 -1.7 7.82 -1.7 15.72 c
++0 7.91 0.34 11.3 1.7 15.72 c
++3.06 9.43 11.48 14.2 21.68 14.2 c
++10.2 0 18.61 -4.76 21.67 -14.2 c
++1.45 -4.42 1.7 -7.82 1.7 -15.72 c
++0 -7.91 -0.25 -11.3 -1.7 -15.72 c
++-3.05 -9.43 -11.47 -14.2 -21.67 -14.2 c
++-10.2 0 -18.61 4.76 -21.68 14.2 c
++f
++386.37 159.86 m
++0 3.74 -2.55 6.12 -6.8 6.12 c
++-7.99 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.21 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++7.99 0 p
++4.25 0 6.8 2.38 6.8 6.12 c
++h
++387.14 120.85 m
++-0.77 0 -1.02 0.25 -1.28 0.85 c
++-8.75 19.72 -5.53 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -19.21 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++13.26 0 20.82 -7.73 20.82 -18.61 c
++0 -7.22 -3.4 -13.09 -9.52 -16.15 c
++10.63 -22.01 p
++0.25 -0.51 0 -1.02 -0.6 -1.02 c
++-14.7 0 p f
++424.8 149.75 m
++0 7.91 0.34 11.3 1.7 15.72 c
++3.06 9.43 11.48 14.2 21.76 14.2 c
++10.63 0 17.76 -4.93 20.99 -12.32 c
++0.26 -0.6 0.09 -1.11 -0.43 -1.36 c
++-11.05 -4.68 p
++-0.51 -0.25 -1.02 -0.08 -1.28 0.34 c
++-1.95 3.15 -4.25 4.68 -8.24 4.68 c
++-3.91 0 -6.46 -1.87 -7.48 -5.1 c
++-0.68 -2.04 -0.85 -4.59 -0.85 -11.48 c
++0 -6.88 0.25 -9.52 0.85 -11.47 c
++1.11 -3.23 3.74 -5.1 7.91 -5.1 c
++3.74 0 6.71 1.62 7.65 4.59 c
++0.34 1.02 0.51 2.21 0.51 3.74 c
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-6.29 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 9.6 p
++0 0.52 0.34 0.85 0.85 0.85 c
++20.65 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -4.42 p
++0 -5.52 -0.34 -9.86 -1.53 -13.43 c
++-3.06 -9.61 -11.22 -14.79 -21.76 -14.79 c
++-10.29 0 -18.7 4.76 -21.76 14.2 c
++-1.36 4.42 -1.7 7.82 -1.7 15.72 c
++f
++533.6 143.2 0 34.59 P
++0 0.51 0.34 0.85 0.85 0.85 c
++13.25 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -35.53 p
++0 -5.78 3.23 -9.09 8.08 -9.09 c
++5.01 0 7.98 3.31 7.98 9.09 c
++0 35.53 p
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -34.59 p
++0 -15.39 -9.18 -23.37 -22.94 -23.37 c
++-14.03 0 -23.04 7.99 -23.04 23.38 c
++f
++605.76 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++12.5 0 p
++0.59 0 1.19 -0.25 1.45 -0.85 c
++17.42 -32.72 0.34 0 0 32.72 p
++0 0.51 0.34 0.85 0.85 0.85 c
++11.9 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-12.5 0 p
++-0.59 0 -1.19 0.25 -1.45 0.85 c
++-17.25 32.64 -0.51 0 0 -32.64 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-11.9 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++678.26 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++735.21 120.85 m
++-0.6 0 -0.93 0.25 -1.11 0.85 c
++-18.44 56.01 p
++-0.17 0.51 0.16 0.93 0.76 0.93 c
++13.94 0 p
++0.59 0 0.93 -0.25 1.1 -0.85 c
++10.29 -34.84 0.26 0 9.94 34.84 p
++0.17 0.6 0.51 0.85 1.11 0.85 c
++13.86 0 p
++0.59 0 0.85 -0.43 0.68 -0.93 c
++-18.45 -56.01 p
++-0.17 -0.59 -0.51 -0.85 -1.11 -0.85 c
++-12.83 0 p f
++790.04 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++37.82 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-23.2 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -8.75 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++19.04 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -10.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-19.04 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.52 c
++0 -9.26 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++23.2 0 p
++0.51 0 0.85 -0.34 0.85 -0.86 c
++0 -10.96 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-37.82 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++884.64 159.86 m
++0 3.74 -2.55 6.12 -6.8 6.12 c
++-7.99 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -11.21 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++7.99 0 p
++4.25 0 6.8 2.38 6.8 6.12 c
++h
++885.41 120.85 m
++-0.77 0 -1.02 0.25 -1.27 0.85 c
++-8.76 19.72 -5.53 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -19.21 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++23.54 0 p
++13.26 0 20.82 -7.73 20.82 -18.61 c
++0 -7.22 -3.4 -13.09 -9.52 -16.15 c
++10.63 -22.01 p
++0.25 -0.51 0 -1.02 -0.6 -1.02 c
++-14.7 0 p f
++922.38 128.08 m
++-0.43 0.34 -0.51 0.93 -0.09 1.36 c
++7.65 9.01 p
++0.34 0.43 0.85 0.43 1.19 0.09 c
++3.48 -3.06 8.93 -5.78 14.71 -5.78 c
++5.35 0 8.16 2.21 8.16 5.44 c
++0 2.47 -1.62 4.08 -7.31 4.84 c
++-3.06 0.43 p
++-12.5 1.79 -19.29 7.39 -19.29 18.19 c
++0 10.8 8.41 18.02 21.5 18.02 c
++7.99 0 15.47 -2.46 20.65 -6.37 c
++0.43 -0.34 0.52 -0.77 0.17 -1.28 c
++-6.37 -9.27 p
++-0.34 -0.43 -0.77 -0.51 -1.19 -0.25 c
++-4.08 2.72 -8.41 4.34 -13 4.34 c
++-4.25 0 -6.37 -2.04 -6.37 -4.84 c
++0 -2.55 1.87 -4.16 7.39 -4.85 c
++3.06 -0.43 p
++12.66 -1.78 19.13 -7.39 19.13 -18.36 c
++0 -10.71 -8.16 -18.53 -23.63 -18.53 c
++-9.43 0 -18.95 4 -23.29 8.25 c
++f
++993.27 177.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++13.26 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-13.26 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++1047.33 120.85 -0.25 0 P
++-0.18 0 -0.26 0.08 -0.43 0.25 c
++-0.08 0.09 -0.17 0.17 -0.17 0.34 c
++0 43.43 p
++0 0.26 -0.17 0.42 -0.43 0.51 c
++-14.53 0 p
++-0.17 0 -0.26 0.08 -0.34 0.17 c
++-0.08 0.08 p
++0 0.09 -0.09 0.09 v
++-0.08 0.17 -0.08 0.34 -0.08 0.51 c
++0 11.56 p
++0 0.43 0.25 0.77 0.59 0.85 c
++44.62 0 p
++0.26 0 0.43 -0.09 0.6 -0.25 c
++0.08 -0.09 0.08 -0.17 v
++0.09 -0.08 0.17 -0.25 0.17 -0.43 c
++0 -11.56 p
++0 -0.25 -0.08 -0.51 -0.25 -0.68 c
++-0.09 -0.09 -0.26 -0.17 -0.43 -0.17 c
++-14.36 0 p
++-0.17 0 -0.26 0 -0.34 -0.09 c
++-0.09 0 -0.09 -0.08 -0.17 -0.16 c
++0 -43.69 p
++-0.09 -0.25 -0.17 -0.34 -0.42 -0.51 c
++-0.09 -0.08 -0.26 -0.08 -0.43 -0.08 c
++-13.26 0 p f
++1113.97 120.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 21.5 -17.51 34.51 p
++-0.17 0.51 0.08 0.93 0.68 0.93 c
++13.34 0 p
++0.6 0 1.02 -0.25 1.36 -0.85 c
++9.69 -19.71 0.26 0 9.51 19.71 p
++0.26 0.6 0.77 0.85 1.37 0.85 c
++13.08 0 p
++0.69 0 0.86 -0.43 0.69 -0.93 c
++-17.51 -34.51 0 -21.5 p
++0 -0.51 -0.35 -0.85 -0.85 -0.85 c
++-13.26 0 p f
++134.06 6.71 m
++-0.34 0.34 -0.43 0.85 -0.08 1.19 c
++2.04 2.55 p
++0.34 0.42 0.85 0.42 1.19 0.08 c
++3.83 -2.98 9.86 -5.95 16.57 -5.95 c
++9.27 0 14.96 4.67 14.96 11.81 c
++0 5.7 -3.23 9.86 -13.85 11.22 c
++-2.64 0.34 p
++-11.3 1.45 -16.66 6.88 -16.66 15.3 c
++0 10.03 7.14 16.23 18.19 16.23 c
++6.38 0 12.49 -1.95 16.49 -4.84 c
++0.42 -0.25 0.51 -0.77 0.17 -1.19 c
++-1.7 -2.63 p
++-0.34 -0.42 -0.76 -0.42 -1.19 -0.17 c
++-4.58 2.8 -9.09 4.25 -14.02 4.25 c
++-8.24 0 -13.09 -4.59 -13.09 -11.3 c
++0 -5.86 3.74 -9.69 13.6 -10.96 c
++2.63 -0.34 p
++11.73 -1.53 16.91 -6.97 16.91 -15.55 c
++0 -9.77 -6.97 -16.74 -20.39 -16.74 c
++-7.56 0 -15.13 3.23 -19.12 6.71 c
++f
++215.91 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-16.65 0 p
++-0.34 0 -0.52 -0.17 -0.52 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++269.04 20.74 m
++0 -10.88 5.53 -16.15 14.71 -16.15 c
++9.26 0 14.79 5.27 14.79 16.15 c
++0 37.05 p
++0 0.51 0.34 0.85 0.86 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -36.97 p
++0 -14.11 -7.65 -20.82 -19.63 -20.82 c
++-11.9 0 -19.55 6.71 -19.55 20.82 c
++0 36.97 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -37.05 p f
++341.12 5.44 12.92 0 P
++7.48 0 12.41 2.64 14.45 8.75 c
++0.93 2.8 1.36 5.78 1.36 15.55 c
++0 9.78 -0.43 12.75 -1.36 15.55 c
++-2.04 6.13 -6.97 8.76 -14.45 8.76 c
++-12.92 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -47.6 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++h
++335.76 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++18.11 0 p
++9.6 0 15.89 -3.82 18.44 -11.73 c
++1.1 -3.4 1.61 -6.62 1.61 -17.17 c
++0 -10.54 -0.51 -13.77 -1.61 -17.17 c
++-2.55 -7.91 -8.84 -11.73 -18.44 -11.73 c
++-18.11 0 p
++-0.5 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++405.46 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++33.06 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-28.55 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -20.57 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++24.56 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-24.56 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.42 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++28.55 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-33.06 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++469.72 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.6 0 1.11 -0.17 1.45 -0.85 c
++28.82 -47.51 0.25 0 0 47.51 p
++0 0.51 0.34 0.85 0.85 0.85 c
++3.14 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -56.09 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.32 0 p
++-0.51 0 -1.02 0.17 -1.45 0.85 c
++-28.55 47.6 -0.34 0 0 -47.6 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++554.8 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-16.66 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++673.71 42.67 m
++0 7.22 -4.59 11.39 -12.84 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.25 0 12.84 4.08 12.84 11.39 c
++h
++674.99 0.85 m
++-0.51 0 -0.77 0.17 -1.02 0.77 c
++-12.15 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.59 -6.12 17.59 -15.98 c
++0 -7.99 -4.42 -13.52 -11.82 -15.3 c
++12.58 -25.59 p
++0.34 -0.51 0.09 -0.93 -0.42 -0.93 c
++-3.91 0 p f
++710.02 57.79 m
++0 0.51 0.34 0.85 0.85 0.85 c
++33.06 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-28.55 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -20.57 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++24.56 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-24.56 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.42 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++28.55 0 p
++0.51 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-33.06 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p f
++807.34 42.24 m
++0 7.39 -4.59 11.81 -13.09 11.81 c
++-14.62 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -22.53 p
++0 -0.34 0.17 -0.51 0.51 -0.51 c
++14.62 0 p
++8.5 0 13.09 4.34 13.09 11.73 c
++h
++775.12 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.29 0 p
++11.05 0 17.77 -6.29 17.77 -16.4 c
++0 -10.12 -6.71 -16.32 -17.77 -16.32 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -23.71 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++872.87 45.13 m
++-2.13 6.37 -6.8 9.77 -13.94 9.77 c
++-7.23 0 -11.9 -3.4 -14.02 -9.77 c
++-0.77 -2.3 -1.45 -6.04 -1.45 -15.39 c
++0 -9.35 0.68 -13.09 1.45 -15.38 c
++2.13 -6.38 6.8 -9.78 14.02 -9.78 c
++7.14 0 11.81 3.4 13.94 9.78 c
++0.76 2.29 1.44 6.03 1.44 15.38 c
++0 9.35 -0.68 13.09 -1.44 15.39 c
++h
++840.23 13 m
++-1.02 3.06 -1.7 6.8 -1.7 16.74 c
++0 9.95 0.68 13.69 1.7 16.74 c
++2.8 8.5 9.26 13 18.7 13 c
++9.35 0 15.8 -4.5 18.61 -13 c
++1.02 -3.05 1.7 -6.8 1.7 -16.74 c
++0 -9.94 -0.68 -13.68 -1.7 -16.74 c
++-2.81 -8.5 -9.26 -13 -18.61 -13 c
++-9.43 0 -15.89 4.5 -18.7 13 c
++f
++942.74 42.67 m
++0 7.22 -4.59 11.39 -12.84 11.39 c
++-14.79 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -21.76 p
++0 -0.34 0.17 -0.52 0.51 -0.52 c
++14.79 0 p
++8.25 0 12.84 4.08 12.84 11.39 c
++h
++944.02 0.85 m
++-0.52 0 -0.77 0.17 -1.02 0.77 c
++-12.15 25.07 -15.72 0 p
++-0.34 0 -0.51 -0.16 -0.51 -0.51 c
++0 -24.48 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 56.09 p
++0 0.51 0.34 0.85 0.85 0.85 c
++19.38 0 p
++10.88 0 17.59 -6.12 17.59 -15.98 c
++0 -7.99 -4.42 -13.52 -11.82 -15.3 c
++12.59 -25.59 p
++0.34 -0.51 0.08 -0.93 -0.43 -0.93 c
++-3.91 0 p f
++991.36 0.85 m
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 51.85 p
++0 0.34 -0.17 0.51 -0.51 0.51 c
++-16.66 0 p
++-0.51 0 -0.85 0.34 -0.85 0.85 c
++0 2.89 p
++0 0.51 0.34 0.85 0.85 0.85 c
++39.18 0 p
++0.52 0 0.85 -0.34 0.85 -0.85 c
++0 -2.89 p
++0 -0.51 -0.33 -0.85 -0.85 -0.85 c
++-16.65 0 p
++-0.34 0 -0.51 -0.17 -0.51 -0.51 c
++0 -51.85 p
++0 -0.51 -0.34 -0.85 -0.85 -0.85 c
++-3.14 0 p f
++739.55 426.54 m
++-10.71 4.8 -21.88 8.79 -40.09 19.88 c
++-51.16 31.19 -66.71 77.61 -37.95 158.58 c
++16.64 46.89 24.64 86.43 20.53 129.09 c
++-0.58 0.38 -1.17 0.75 -1.75 1.13 c
++-2.68 -53.57 -22.43 -86.88 -57.81 -143.26 c
++-74.96 -119.45 1.14 -206.99 37.3 -234.22 c
++31.89 16.07 59.27 39.8 79.77 68.8 c
++f
++587.75 596.32 m
++57.8 68.03 76.59 99.39 80.49 146.2 c
++-0.62 0.34 -1.23 0.73 -1.85 1.07 c
++-13.39 -56.01 -46.97 -85.69 -135.46 -144.63 c
++-95.32 -63.47 -91.04 -172.59 -66.77 -240.51 c
++29.57 -15.17 63.02 -23.79 98.52 -23.79 c
++7.56 0 15.04 0.4 22.41 1.16 c
++-68.82 104.42 -64.05 181.96 2.67 260.49 c
++f
++552.43 646.52 m
++63.84 27.7 94.1 69.77 102.85 102.71 c
++-0.55 0.27 -1.14 0.52 -1.7 0.78 c
++-27.79 -58.13 -83.26 -67.83 -178.1 -80.54 c
++-56.23 -7.54 -99.97 -39.76 -126.37 -79.64 c
++-2.1 -12.17 -3.27 -24.68 -3.27 -37.46 c
++0 -51.83 18.07 -99.39 48.18 -136.77 c
++-2.68 162.79 81.88 197.73 158.41 230.92 c
++f
++cleartomark end end pagesave restore
++ showpage
++%%PageTrailer
++%%Trailer
++%%Pages: 1
+diff --git a/Statusseminar/figures/dotexample.pdf b/Statusseminar/figures/dotexample.pdf
+new file mode 100644
+index 0000000..1a552b6
+Binary files /dev/null and b/Statusseminar/figures/dotexample.pdf differ
+diff --git a/Statusseminar/figures/tables/lexemes.tex b/Statusseminar/figures/tables/lexemes.tex
+new file mode 100644
+index 0000000..8301922
+--- /dev/null
++++ b/Statusseminar/figures/tables/lexemes.tex
+@@ -0,0 +1,12 @@
++	\begin{tabular}{ll}
++		\toprule
++		Token & Regulært udtryk \\
++		\midrule
++		IntLiteral & \texttt{(+|-)?[0-9]+}\\
++		FloatLiteral & \texttt{(+|-)?[0-9]+\textbackslash{}.[0-9]+}\\
++		CharLiteral & \texttt{`(\textbackslash{}\textbackslash{}(`$\vert$\textbackslash{}\textbackslash{})$\vert{}$[\^{}'\textbackslash{}\textbackslash{}])'}\\
++		StringLiteral & \texttt{\textbackslash{}\textquotedblleft{}(\textbackslash{}\textbackslash{}(n|{}t|{}\textbackslash{}\textbackslash{})|[\^{}\textbackslash{}\textquotedblright{}\textbackslash{}\textbackslash{}\textbackslash{}n])*\textbackslash{}\textquotedblright{}}\\
++		BoolLiteral & \texttt{true} | \texttt{false}\\
++		Id & \texttt{[a-zA-Z\_][a-zA-Z0-9\_]*}\\
++		\bottomrule
++	\end{tabular}
+\ No newline at end of file
+diff --git a/Statusseminar/listings/cgraf.c b/Statusseminar/listings/cgraf.c
+new file mode 100644
+index 0000000..b025ac0
+--- /dev/null
++++ b/Statusseminar/listings/cgraf.c
+@@ -0,0 +1,52 @@
++#include <stdlib.h>
++
++#define EDGE_IN_GRAPH 1
++#define VERTEX_OUT_OF_RANGE -1
++
++//Doubly linked list
++struct node_t { 
++    int val;
++    struct node_t* next;
++    struct node_t* prev;
++} node;
++
++typedef struct {
++    int num_vertices;
++    struct node_t *adj[];
++} graph_t;
++
++int add_edge(graph_t *graph, int start, int end);
++struct node_t *create_node(struct node_t *prev, int val, struct node_t *next);
++
++int add_edge(graph_t *graph, int start, int end) 
++{
++    if (start > graph->num_vertices) {
++        return VERTEX_OUT_OF_RANGE; //Error code: start is not a vertex in graph
++    }
++    struct node_t *node = graph->adj[start];
++    //Skip to end of adjacency list
++    while (node->next != NULL) {
++        if (node->val == end) {
++            return EDGE_IN_GRAPH; //Edge already in graph
++        }
++        node = node->next;
++    }
++    struct node_t *next = create_node(node, end, NULL);
++    node->next = next;
++    return 0; //Success
++}
++
++struct node_t *create_node(struct node_t *prev, int val, struct node_t *next) 
++{
++    struct node_t *node = (struct node_t*) malloc(sizeof(struct node_t));
++    node->prev = prev;
++    node->next = next;
++    node->val  = val;
++    return node;
++}
++
++
++int main(int argc, char *argv[]) 
++{
++    return 0;
++}
+\ No newline at end of file
+diff --git a/Statusseminar/listings/knud/blockillegal.tex b/Statusseminar/listings/knud/blockillegal.tex
+new file mode 100644
+index 0000000..b87a2e8
+--- /dev/null
++++ b/Statusseminar/listings/knud/blockillegal.tex
+@@ -0,0 +1,7 @@
++//Ulovlig
++if (expr) 
++	//...
++else if (expr)
++	//...
++else
++	//... 
+\ No newline at end of file
+diff --git a/Statusseminar/listings/knud/blocklegal.tex b/Statusseminar/listings/knud/blocklegal.tex
+new file mode 100644
+index 0000000..7ab184d
+--- /dev/null
++++ b/Statusseminar/listings/knud/blocklegal.tex
+@@ -0,0 +1,7 @@
++//Lovlig
++if (expr) {
++	//...
++}
++else if {
++	//...
++}
+\ No newline at end of file
+diff --git a/Statusseminar/listings/knud/graphattributeaddition.tex b/Statusseminar/listings/knud/graphattributeaddition.tex
+new file mode 100644
+index 0000000..e725306
+--- /dev/null
++++ b/Statusseminar/listings/knud/graphattributeaddition.tex
+@@ -0,0 +1,11 @@
++void foo(graph G) {
++	//Erklæring af nye attributter på G
++	define(G) {
++		vertex int a;
++		vertex int b = 0;
++	}
++	// ...
++	for (vertex v in V(G)) {¤\label{lstline:specifikation_cfg_forloopeksempel}¤
++		v.a = 0;¤\label{lstline:specifikation_cfg_grafattributeksempel_assign}¤
++	}
++}
+\ No newline at end of file
+diff --git a/Statusseminar/listings/knud/graphdclexample.tex b/Statusseminar/listings/knud/graphdclexample.tex
+new file mode 100644
+index 0000000..7a8f660
+--- /dev/null
++++ b/Statusseminar/listings/knud/graphdclexample.tex
+@@ -0,0 +1,9 @@
++graph G = graph {
++	vertex int a;¤\label{lstline:specifikation_cfg_grafeksempel_attrdclstart}¤
++	vertex int b = 0; //Standard-værdi
++	edge float c;¤\label{lstline:specifikation_cfg_grafeksempel_attrdclend}¤
++	//Alle kanter får c = 0.5
++	A -- B -- C [c = 0.5];
++	//Kanterne får c = hhv. 0.3, 0.5, 0.8. 
++	D -- E -- F -- G [c = {0.3, 0.5, 0.8}];
++} 
+diff --git a/Statusseminar/listings/knud/invariant.tex b/Statusseminar/listings/knud/invariant.tex
+new file mode 100644
+index 0000000..8ab322c
+--- /dev/null
++++ b/Statusseminar/listings/knud/invariant.tex
+@@ -0,0 +1,3 @@
++graph G;
++// ...
++for (vertex v in V(G)) invariant()
+\ No newline at end of file
+diff --git a/Statusseminar/listings/kode_eksempler/BFS.tex b/Statusseminar/listings/kode_eksempler/BFS.tex
+new file mode 100644
+index 0000000..10b5d3c
+--- /dev/null
++++ b/Statusseminar/listings/kode_eksempler/BFS.tex
+@@ -0,0 +1,48 @@
++\begin{lstlisting}[caption={Udregning af BFS},escapechar=¤]
++digraph G = digraph {
++// DOT-like syntaks: Tre implicit erklærede knuder, kanter mellem dem (grafen er en 3-cykel) og specificerede kantvægte.
++  edge float weight = 0;
++  q1 -> q2 -> q3 -> q1 [weight = {0.5, 0.3, 0.4}];
++}
++
++digraph BFS(graph G, vertex s, int k)
++  // Definerer attributter for grafen
++  define(G) {
++    //Attribut på knuder med optional default-værdi
++    vertex int d = int_max;
++    vertex Color color = white;
++    vertex vertex parent = null;
++  }
++{
++  assert s in V(G);
++
++  // En kø og en linked list er bare orienterede grafer  
++  digraph Q = CreateEmptyQueue();
++  digraph dest = CreateEmptyList();
++
++  s.color = gray;
++  s.d = 0;
++  Enqueue(Q, s);
++
++  //|Q| Kardinaliteten af knudemængden
++  while(|Q| > 0)
++  {
++    vertex u = Dequeue(Q);
++    if(u.d <= k) { 
++      InsertToList(dest, u); 
++    }
++
++    // G.Adj[u] er nabomængden for u i G
++    for (vertex v in G.Adj[u]) { 
++      if (v.color == white) { 
++        v.color = gray;
++        v.d = u.d + 1;
++        v.parent = u;
++        Enqueue(Q,v);
++      }
++    }
++    u.color = black;
++  }
++  return dest;
++}
++\end{lstlisting}
+diff --git a/Statusseminar/listings/kode_eksempler/Euler.tex b/Statusseminar/listings/kode_eksempler/Euler.tex
+new file mode 100644
+index 0000000..63700f9
+--- /dev/null
++++ b/Statusseminar/listings/kode_eksempler/Euler.tex
+@@ -0,0 +1,156 @@
++\begin{lstlisting}[caption={Udregning af Euler-kreds.},escapechar=¤]
++// Denne graf repræsenterer kantmængden {(q1, q2), (q2,q3), (q3,q4), (q4,q6), (q1,q3), (q3,q5), (q5,q6)}.
++graph G = graph {
++  q1 -- q2 -- q3 -- q4 -- q6;
++  q1 -- q3 -- q5 -- q6;
++}
++
++// Her checker vi om man kan lave en euler kreds i den givne graf.
++digraph EulerCircuit(graph G)
++{
++  digraph list = CreateEmptyList();
++
++  if(not StronglyConnectedComponent(G)) {
++    return list;
++  }
++  // Knudemængden i G
++  for (vertex v in V(G)) {
++    // |G.Adj[v] er størrelsen af nabolisten til v
++    if (|G.Adj[v]| % 2 != 0) {
++      return list;
++    }
++  }
++
++  // Her laves en deep copy af G
++  graph Copy = val G;
++  vertex start = RandomElement(V(G));
++  digraph bridges = Bridges(Copy);
++
++  vertex cur = start;
++  InsertToList(list, start);
++    
++  // ||Copy|| = Antal kanter i grafen
++  while(||Copy|| > 0) 
++  {
++    edge target = First(Copy.AdjEdge[cur]);
++    for (edge e in Copy.AdjEdge[cur])
++    {
++      if(!IsBridge(e)){
++        target = e;
++      }
++    }
++
++    // Kant, target, går fra cur til x, hvor Opposite returner x
++    cur = Opposite(target, cur);
++    InsertToList(list, cur);
++    Copy = Copy - target;
++  }
++}
++
++// Hjælpefunktion til at finde ud af om en kant er en bridge
++bool IsBridge(Graph G, edge e)
++{
++  digraph bridges = Bridges(G);
++  for (edge g in E(bridges))
++  {
++    if(g == e) {
++      return true;
++    }
++  }
++  return false;
++}
++
++bool StronglyConnectedComponent(graph G) 
++  define(G) {
++    vertex int index = int_max;
++    vertex int lowlink = int_max;
++    vertex bool onStack = false;
++  }
++{
++  int index = 0;
++  graph stack = CreateEmptyStack();
++  graph finalStack = CreateEmptyStack();
++
++  for (vertex v in V(G))
++  {
++    if(v.index == int_max) {
++      index = StrongConnect(G, v, stack, finalStack, index);
++    }
++  }
++    
++  return V(G) == V(finalStack);
++}
++
++int StrongConnect(graph G, vertex v, digraph S, digraph F, int index) {
++  v.index = index;
++  v.lowlink = index;
++  index++;
++  PushOnStack(S, v);
++  v.onStack = true;
++
++  for (edge e in E(G))
++  {
++    vertex w = Opposite(G, v);
++    if(w.index == int_max) {
++      index = StrongConnect(G, w, S, F, index);
++    }
++    else if(w.onStack) {
++      v.lowlink = min(v.lowlink, w.index);
++    }
++  }
++
++  if (v.lowlink == v.index) {  
++    do {
++      vertex w = PopFromStack(S); 
++      w.onStack = false;
++      PushOnStack(F, w);
++    } while(w != v);
++  } 
++
++  return index;
++}
++
++digraph Bridges(graph G)
++{
++  digraph bridges = CreateEmptyList();
++  for (edge e in E(G)) 
++  {
++    G = G - e;
++    IsBridge = BFSReachable(G, Source(e), Dest(e));
++    if(IsBridge) {
++      InsertToList(bridges, e);
++    }
++    G = G + e;
++  }
++
++  return bridges;
++}
++
++bool BFSReachable(graph G, vertex s, vertex fini)
++  define(G) {
++    vertex bool visited = false;
++  }
++{
++  assert s in V(G), ''s must be contained in G'';
++  assert fini in V(G), ''fini must be contained in G'';
++  
++  digraph Q = CreateEmptyQueue();
++
++  s.visited = true;
++  Enqueue(Q, s);
++
++  while(|Q| > 0) //|Q| Kardinaliteten af knudemængden
++  {
++    vertex u = Dequeue(Q);
++
++    // G.Adj[u] er nabomængden for u i G
++    for (vertex v in G.Adj[u]) { 
++      if (not v.visited) { 
++        v.visited = true;
++        Enqueue(Q,v);
++      }
++    }
++  }
++  return not fini.visited;
++}
++\end{lstlisting}
+\ No newline at end of file
+diff --git a/Statusseminar/listings/kode_eksempler/graf_i_c.tex b/Statusseminar/listings/kode_eksempler/graf_i_c.tex
+new file mode 100644
+index 0000000..bc2aa9b
+--- /dev/null
++++ b/Statusseminar/listings/kode_eksempler/graf_i_c.tex
+@@ -0,0 +1,45 @@
++\begin{lstlisting}[caption={Grafer i C.},label={lst:app_cgraph},escapechar=¤]
++#include <stdlib.h>
++#define EDGE_IN_GRAPH 1
++#define VERTEX_OUT_OF_RANGE -1
++
++//Doubly linked list
++struct node_t { 
++	int val;
++	struct node_t* next;
++	struct node_t* prev;
++} node;
++typedef struct {
++	int num_vertices;
++	struct node_t *adj[];
++} graph_t;
++
++int add_edge(graph_t *graph, int start, int end);
++struct node_t *create_node(struct node_t *prev, int val, struct node_t *next);
++
++int add_edge(graph_t *graph, int start, int end) 
++{
++	if (start > graph->num_vertices)
++		return VERTEX_OUT_OF_RANGE; //Error code: start is not a vertex in graph
++	
++	struct node_t *node = graph->adj[start];
++	//Skip to end of adjacency list
++	while (node->next != NULL) {
++		if (node->val == end)
++			return EDGE_IN_GRAPH; //Edge already in graph
++		node = node->next;
++	}
++	struct node_t *next = create_node(node, end, NULL);
++	node->next = next;
++	return 0; //Success
++}
++
++struct node_t *create_node(struct node_t *prev, int val, struct node_t *next) 
++{
++	struct node_t *node = (struct node_t*) malloc(sizeof(struct node_t));
++	node->prev = prev;
++	node->next = next;
++	node->val  = val;
++	return node;
++}
++\end{lstlisting}
+\ No newline at end of file
+diff --git a/Statusseminar/lstautodedent.sty b/Statusseminar/lstautodedent.sty
+new file mode 100644
+index 0000000..d2d10ea
+--- /dev/null
++++ b/Statusseminar/lstautodedent.sty
+@@ -0,0 +1,141 @@
++%%
++%% This is file `lstautodedent.sty',
++%% generated with the docstrip utility.
++%%
++%% The original source files were:
++%%
++%% lstautodedent.dtx  (with options: `package')
++%% 
++%% This is a generated file.
++%% 
++%% Copyright (C) 2014 by Julien Cretel <jubobs.tex at gmail.com>
++%% 
++%% This work may be distributed and/or modified under the
++%% conditions of the LaTeX Project Public License, either version 1.3
++%% of this license or (at your option) any later version.
++%% The latest version of this license is in
++%% 
++%%     http://www.latex-project.org/lppl.txt
++%% 
++%% and version 1.3 or later is part of all distributions of LaTeX
++%% version 2005/12/01 or later.
++%% 
++%% This work has the LPPL maintenance status `maintained'.
++%% 
++%% The Current Maintainer of this work is Julien Cretel.
++%% 
++%% This work currently consists of the files lstautodedent.dtx,
++%% lstautodedent.ins, and the derived file lstautodedent.sty.
++%% 
++\NeedsTeXFormat{LaTeX2e}[2011/06/27]
++\ProvidesPackage{lstautodedent}
++  [2014/05/20 v0.1 A package for automatically dedenting listings]
++\RequirePackage{listings}
++\lst@Key{autodedent}f[t]{\lstKV@SetIf{#1}\ifautodedent@lstad@}
++
++\newtoks\toks@lstad
++\toks@lstad={%
++    \lst@DefSaveDef{`\ }\space@lstad{\processSpace@lstad}%
++    %\lst@DefSaveDef{`\^^I}\tab@lstad{\processTab@lstad} % currently not used
++}
++
++\newcommand\add@savedef@lstad{}
++\def\add@savedef@lstad#1#2{%
++  \begingroup\lccode`?=#1\relax
++  \lowercase{\endgroup
++    \edef\@tempa{%
++      \noexpand\lst@DefSaveDef{\number#1}%
++      \expandafter\noexpand\csname ?@lstad\endcsname{\noexpand#2%
++      \expandafter\noexpand\csname ?@lstad\endcsname}%
++    }%
++  }%
++  \toks@lstad=\expandafter{\the\expandafter\toks@lstad\@tempa}%
++}
++
++\count@=33
++\loop
++    \add@savedef@lstad\count@\processchar@lstad
++  \ifnum\count@<127
++  \advance\count@\@ne
++\repeat
++
++\newcount\spacesToGobble@lstad
++\newcount\spacesGobbledSoFar@lstad
++\newif\ifafterindent@lstad@
++\newif\ifonBasisLine@lstad@
++\newif\ifPostponeCount@lstad@
++
++\lst@AddToHook{Init}
++{%
++  \ifautodedent@lstad@%
++    % patch hook macros
++    \let\@ddedToInitVarsBOLhook@lstad\@@ddedToInitVarsBOLhook@lstad%
++    \let\@ddedToEOLhook@lstad\@@ddedToEOLhook@lstad%
++    % initialise things
++    \global\onBasisLine@lstad@true%
++    \global\afterindent@lstad@false%
++    \global\spacesToGobble@lstad=0%
++    \lst@ifincluderangemarker%
++      % if firtline option is not used
++      \ifnum9999999=\lst@firstline%
++        \global\PostponeCount@lstad@true%
++      \fi
++    \fi
++  \fi
++}
++
++\lst@AddToHook{SelectCharTable}
++{%
++  \ifautodedent@lstad@%
++    \lst@lAddTo\lst@DeveloperSCT{\the\toks@lstad}%
++  \fi
++}
++
++\lst@AddToHook{InitVarsBOL}{\@ddedToInitVarsBOLhook@lstad}
++\newcommand\@ddedToInitVarsBOLhook@lstad{}
++\newcommand\@@ddedToInitVarsBOLhook@lstad{\global\afterindent@lstad@false}
++
++\lst@AddToHook{EOL}{\@ddedToEOLhook@lstad}
++\newcommand\@ddedToEOLhook@lstad{}
++\newcommand\@@ddedToEOLhook@lstad
++{%
++  \ifonBasisLine@lstad@%
++    \ifPostponeCount@lstad@%
++    \else
++      \global\onBasisLine@lstad@false%
++    \fi
++  \fi
++  \global\spacesGobbledSoFar@lstad=0%
++  \global\PostponeCount@lstad@false%
++}
++
++\lst@AddToHook{DeInit}
++{%
++  \ifautodedent@lstad@%
++    % undo patches
++    \renewcommand\@ddedToInitVarsBOLhook@lstad{}%
++    \renewcommand\@ddedToEOLhook@lstad{}%
++  \fi
++}
++
++\newcommand\processchar@lstad{\global\afterindent@lstad@true}
++
++\newcommand\processSpace@lstad
++{%
++  \ifafterindent@lstad@%
++    \space@lstad%
++  \else
++    \ifonBasisLine@lstad@%
++      \global\advance\spacesToGobble@lstad\@ne\relax%
++    \else
++      \ifnum\spacesGobbledSoFar@lstad<\spacesToGobble@lstad\relax%
++        \global\advance\spacesGobbledSoFar@lstad\@ne\relax%
++      \else
++        \space@lstad%
++      \fi
++    \fi
++  \fi
++}
++\endinput
++%%
++%% End of file `lstautodedent.sty'.
+diff --git a/Statusseminar/master.tex b/Statusseminar/master.tex
+new file mode 100755
+index 0000000..cd1c1ae
+--- /dev/null
++++ b/Statusseminar/master.tex
+@@ -0,0 +1,54 @@
++%  A simple AAU report template.
++%  2015-05-08 v. 1.2.0
++%  Copyright 2010-2015 by Jesper Kjær Nielsen <jkn@es.aau.dk>
++%
++%  This is free software: you can redistribute it and/or modify
++%  it under the terms of the GNU General Public License as published by
++%  the Free Software Foundation, either version 3 of the License, or
++%  (at your option) any later version.
++%
++%  This is distributed in the hope that it will be useful,
++%  but WITHOUT ANY WARRANTY; without even the implied warranty of
++%  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++%  GNU General Public License for more details.
++%
++%  You can find the GNU General Public License at <http://www.gnu.org/licenses/>.
++%
++\input{setup/preamble.tex}% package inclusion and set up of the document
++\input{setup/hyphenations.tex}% 
++\input{setup/macros.tex}% my new macros
++\input{setup/acronyms.tex}
++
++\makeglossary
++
++\title{Arbejdsblad statusseminar}
++\author{D409F18}
++
++\begin{document}
++%frontmatter
++\pagestyle{empty} %disable headers and footers
++\pagenumbering{roman} %use roman page numbering in the frontmatter
++%\input{sections/frontpage.tex}
++%\input{sections/colophon.tex}
++%\input{sections/titlepages.tex}
++\maketitle
++\clearpage
++\cleardoublepage
++\pdfbookmark[0]{Contents}{label:contents}
++\pagestyle{fancy} %enable headers and footers again
++\tableofcontents
++%\listoftodos
++%\input{sections/preface.tex}
++\cleardoublepage
++%mainmatter
++\pagenumbering{arabic} %use arabic page numbering in the mainmatter
++\include{sections/statusseminar}
++\label{pg:lastpage}
++\printbibliography[heading=bibintoc]
++\label{bib:mybiblio}
++\appendix
++\input{sections/appAname.tex}
++\input{sections/appMoscow.tex}
++%\appendix
++%\input{sections/appAname.tex}
++\end{document}
+diff --git a/Statusseminar/sections/appAname.tex b/Statusseminar/sections/appAname.tex
+new file mode 100755
+index 0000000..706c5cc
+--- /dev/null
++++ b/Statusseminar/sections/appAname.tex
+@@ -0,0 +1,42 @@
++\appendix
++\appendixpage
++\pagenumbering{arabic}
++\renewcommand{\thepage}{\alphalph{\value{page}}}
++\addappheadtotoc
++%---------Insert appendixes here---------------
++\chapter{Grafer i C}\label{app:graf-i-C}
++\input{listings/kode_eksempler/graf_i_c.tex}
++
++%\chapter{Kontekst fri grammatik i Backus-Naur formalitet}
++%\input{sections/appendix/bnf.tex}\label{app:bnf}
++
++%\chapter{Kode eksempler: BFS}
++%\input{listings/kode_eksempler/BFS.tex}
++%
++%\chapter{Kode eksempler: Euler}
++%\input{listings/kode_eksempler/Euler.tex}
++
++\chapter{DOT kode eksempel} \label{app:DOT}
++\begin{figure}[h]
++	\begin{minipage}[b]{0.5\textwidth}
++		\begin{lstlisting}
++digraph G {
++	A -> B -> C [color = red, style = dotted];
++	A -> D [color=blue];
++	D -> A;
++	A -> E;
++}
++		\end{lstlisting}
++		\subcaption{Simpelt eksempel på DOT kode.}
++		\label{fig:problemanalyse_stateoftheart_dot_dotinput}
++		
++	\end{minipage}
++	\hfill
++	\begin{minipage}[b]{0.5\textwidth}
++		\includegraphics[width=\linewidth]{figures/dotexample.pdf}
++		\subcaption{Outputtet af \texttt{dot}.}
++		\label{fig:problemanalyse_stateoftheart_dot_dotoutput}
++	\end{minipage}
++	\caption{Eksempel på DOT kode og korresponderende output.}
++\end{figure}
++
+diff --git a/Statusseminar/sections/appMoscow.tex b/Statusseminar/sections/appMoscow.tex
+new file mode 100644
+index 0000000..c033b77
+--- /dev/null
++++ b/Statusseminar/sections/appMoscow.tex
+@@ -0,0 +1,110 @@
++\chapter{Funktionelle krav}\label{app:MoSCoW}
++\section{Must have}
++\begin{itemize}
++	\item Aritmetik
++	\item Assignment
++	\begin{itemize}
++		\item Reference-assignment
++		\item Deep-copy
++	\end{itemize}
++	\item Funktioner
++	\begin{itemize}
++		\item Parametre
++		\begin{itemize}
++			\item Pass-by-reference
++			\item Pass-by-value
++		\end{itemize}
++		\item Single return
++	\end{itemize}
++	\item Statiske typer
++	\item Elementære datatyper
++	\begin{itemize}
++		\item Heltal
++		\item Flyende kommatal
++		\item Tegn
++		\item Booleske værdier
++		\item Streng
++	\end{itemize}
++	\item Mængder
++	\item Kontrolstrukturer
++	\begin{itemize}
++		\item Iterative
++		\begin{itemize}
++			\item While
++			\item Foreach
++		\end{itemize}
++		\item Selektive
++		\begin{itemize}
++			\item If
++			\item Else if
++			\item Else
++		\end{itemize}
++	\end{itemize}
++	\item Logiske udtryk
++	\begin{itemize}
++		\item And
++		\item Or
++		\item Not
++		\item Relationelle udtryk
++		\begin{itemize}
++			\item <
++			\item >
++			\item <=
++			\item >=
++			\item ==
++			\item !=
++		\end{itemize}
++	\end{itemize}
++	\item Assertions og løkkeinvarianter
++	\item Garbage collection
++	\item Grafer
++	\begin{itemize}
++		\item Kanter
++		\item Knuder
++		\item Initialisering
++		\item Attributer på knuder og kanter
++		\item Grafoperationer
++		\begin{itemize}
++			\item Addere kunde og kant til graf
++			\item Union to grafer
++			\item Subtrahere knude, kant og graf til graf
++		\end{itemize}
++		\item Nabomængde til knuder i en graf
++	\end{itemize}
++\end{itemize}
++
++\section{Should have}
++\begin{itemize}
++	\item Funktioner på grafer, knuder og kanter (Eks. \texttt{G.count();})
++	\item Induceret subgraf
++	\item Enum
++	\item Switch 
++	\item Grafer
++	\begin{itemize}
++		\item Join
++		\item Komplement
++		\item Mulighed for at få naborepræsentationerne (Nabomatrice, naboliste)
++		\item Orden
++		\item Antal kanter
++	\end{itemize}
++	\item Funktioner som parametre til funktioner
++\end{itemize}
++
++\section{Could have}
++\begin{itemize}
++	\item Grafer
++	\begin{itemize}
++		\item Kartetisk produkt
++		\item $ K_n $ Komplet graf
++		\item $ C_n $ Cyklisk graf
++		\item $ P_n $ Vejgraf
++	\end{itemize}
++	\item Generics
++	\item Array
++	\item Multiple return
++\end{itemize}
++
++\section{Won’t have}
++\begin{itemize}
++	\item Error handling
++\end{itemize}
+\ No newline at end of file
+diff --git a/Statusseminar/sections/appendix/bnf.tex b/Statusseminar/sections/appendix/bnf.tex
+new file mode 100644
+index 0000000..1164656
+--- /dev/null
++++ b/Statusseminar/sections/appendix/bnf.tex
+@@ -0,0 +1,87 @@
++\begin{bnf*}
++\bnfprod{Prog}{\bnfpn{Cmds}}\\
++\bnfprod{Cmds}{\bnfpn{Cmd}\bnfpn{Cmds} \bnfor \bnfes}\\
++\bnfprod{Cmd}{\bnfpn{Stmt}\bnfor\bnfpn{Dcl}}\\
++\bnfprod{Dcl}{\bnfpn{VarDcl} \bnfor \bnfpn{FuncDcl} \bnfor \bnfpn{EnumDcl}}\\
++\bnfprod{VarDcl}{\bnfpn{Type} \bnfsp \bnfpn{Id} \bnfsp \bnfpn{InitOpt} \bnfts{ ; } }\\
++\bnfprod{InitOpt}{\bnfts{ = }\bnfpn{Expr} \bnfor \bnfes }\\
++\bnfprod{Stmt}{\bnfpn{AssignStmt} \bnfts{ ; } \bnfor \bnfpn{ReturnStmt} \bnfts{ ; } \bnfor \bnfpn{WhileStmt} \bnfnlor \bnfpn{ForEachStmt} \bnfor \bnfpn{IfStmt} } \bnfor \bnfpn{AssertStmt} \bnfts{ ; } \\
++\bnfprod{ArithExpr}{\bnfpn{ArithExpr} \bnfpn{ArithOp} \bnfpn{Term} \bnfor \bnfpn{Term}}\\
++\bnfprod{ArithOp}{\bnfts{+} \bnfor \bnfts{-}}\\
++\bnfprod{Term}{\bnfpn{Term} \bnfsp\bnfpn{TermOp}\bnfsp \bnfpn{Factor} \bnfor \bnfpn{Factor}}\\
++\bnfprod{TermOp}{\bnfts{*} \bnfor \bnfts{/} \bnfor \bnfts{\%}}\\
++\bnfprod{Factor}{\bnfts{(}\bnfpn{ArithExpr}\bnfts{)}
++		\bnfor \bnfpn{Field} \bnfor \bnfpn{FuncCall} \bnfor \bnfpn{IntLiteral} \bnfnlor \bnfpn{FloatLiteral} \bnfor \bnfpn{Cardinality} \bnfor \bnfpn{NumEdges}}\\
++\bnfprod{Id}{id}\\
++\bnfprod{Field}{\bnfpn{Id} \bnfor \bnfpn{Field}\bnfts{.}\bnfpn{Id}}\\
++\bnfprod{Expr}{\bnfpn{ArithExpr} \bnfor \bnfpn{OrExpr} \bnfor \bnfpn{GraphLit} \bnfor \bnfpn{EdgeLit} \bnfnlor \bnfpn{VertexLit} \bnfor \bnfpn{StringLiteral} \bnfor \bnfpn{CharLiteral}}\\
++%\bnfprod{LogicExpr}{\bnfpn{OrExpr} }\\
++\bnfprod{OrExpr}{\bnfpn{AndExpr} \bnfor \bnfpn{OrExpr} \bnfsp \bnfts{or}\bnfsp \bnfpn{AndExpr}}\\
++\bnfprod{AndExpr}{\bnfpn{NotExpr} \bnfor \bnfpn{AndExpr} \bnfsp\bnfts{and}\bnfsp \bnfpn{NotExpr}}\\
++\bnfprod{NotExpr}{\bnfts{not} \bnfsp \bnfpn{RelExpr} \bnfor \bnfpn{RelExpr}}\\
++\end{bnf*}
++
++\begin{bnf*}
++\bnfprod{RelExpr}{\bnfts{(} \bnfpn{OrExpr} \bnfts{)} \bnfor \bnfpn{BoolLiteral} \bnfor \bnfpn{Field} \bnfnlor \bnfpn{ArithExpr} \bnfpn{RelOp} \bnfpn{ArithExpr}\bnfor \bnfpn{ElementInSet}}\\
++\bnfprod{RelOp}{\bnfts{<} \bnfor \bnfts{<=} \bnfor \bnfts{>} \bnfor\bnfts{>=} \bnfor\bnfts{==} \bnfor \bnfts{!=} }\\
++\bnfprod{AssignStmt}{\bnfpn{Id} \bnfts{=} \bnfpn{ByValue} \bnfpn{Expr}}\\
++\bnfprod{GraphLit}{\bnfpn{GraphType}\bnfts{ \{ } \bnfpn{GraphStmtList} \bnfts{ \} }}\\
++\bnfprod{GraphType}{\bnfts{graph} \bnfor \bnfts{digraph}}\\
++\bnfprod{GraphStmtList}{\bnfpn{GraphStmt} \bnfts{ ; } \bnfpn{GraphStmtList} \bnfor \bnfes}\\
++\bnfprod{GraphStmt}{\bnfpn{EdgeStmt} \bnfor \bnfpn{VertexStmt} \bnfor \bnfpn{GraphAttrDcl}  } \\
++\bnfprod{EdgeStmt}{\bnfpn{Id} \bnfpn{EdgeOp} \bnfpn{EdgeStmtAux} \bnfpn{EdgeAttrList}}\\
++\bnfprod{EdgeStmtAux}{\bnfpn{Id} \bnfpn{EdgeOp} \bnfpn{EdgeStmtAux} \bnfor \bnfpn{Id} }\\
++\bnfprod{EdgeAttrList}{\bnfts{[ } \bnfpn{EdgeAttrAux} \bnfts{ ] }\bnfor \bnfes}\\
++\bnfprod{EdgeAttrAux}{\bnfpn{EdgeAttr} \bnfts{ , } \bnfpn{EdgeAttrAux} \bnfor \bnfpn{EdgeAttr}}\\
++\bnfprod{EdgeAttr}{\bnfpn{Id} \bnfts{ = } \bnfpn{EdgeAttrRHS}}\\
++\bnfprod{EdgeAttrRHS}{\bnfpn{Expr} \bnfor \bnfts{ \{ } \bnfpn{EdgeAttrVals} \bnfts{ \} } }\\
++%Expr eller EdgeAttrVal? 
++\bnfprod{EdgeAttrVals}{\bnfpn{Expr} \bnfts{ , } \bnfpn{EdgeAttrVals} \bnfor \bnfpn{Expr}}\\
++\bnfprod{EdgeOp}{\bnfts{-}\bnfts{-} \bnfor \bnfts{->} \bnfor \bnfts{<->}}\\
++\bnfprod{VertexStmt}{\bnfpn{Id}\bnfpn{SimpleAttrList}}\\
++%\bnfprod{GraphAttrAssign}{\bnfpn{Id} \bnfpn{GraphAttrStmts}}\\
++\bnfprod{GraphAttrDcl}{\bnfpn{VertEdgeKW} \bnfpn{VarDcl} }\\
++\bnfprod{VertEdgeKW}{\bnfts{vertex} \bnfor \bnfts{edge}}\\
++\bnfprod{Type}{\bnfts{int} \bnfor \bnfts{char} \bnfor \bnfts{bool} \bnfor \bnfts{float} \bnfor \bnfts{string} \bnfnlor \bnfts{vertex} \bnfor \bnfts{edge} \bnfor \bnfpn{GraphType}}\\
++\bnfprod{EdgeLit}{\bnfts{edge \{ } \bnfpn{Id}\bnfpn{EdgeOp}\bnfpn{Id} \bnfpn{SimpleAttrList} \bnfts{ \}} }\\
++\bnfprod{SimpleAttrList}{ \bnfts{[ } \bnfpn{SimpleAttr} \bnfts{ ]} \bnfor \bnfes}\\
++\bnfprod{SimpleAttr}{\bnfpn{AssignStmt} \bnfts{ , } \bnfpn{SimpleAttr} \bnfor \bnfpn{AssignStmt}}\\
++\bnfprod{VertexLit}{\bnfts{vertex \{ } \bnfpn{VertexStmt} \bnfts{  \} } }\\
++\bnfprod{FuncDcl}{\bnfpn{Type} \bnfpn{Id} \bnfts{ ( } \bnfpn{FuncArgs} \bnfts{ ) } \bnfpn{Define} \bnfpn{Block}}\\
++\bnfprod{FuncArgs}{\bnfpn{FuncArgList} \bnfor \bnfes}\\
++\bnfprod{FuncArgList}{\bnfpn{FuncArg} \bnfts{ , } \bnfpn{FuncArgList} \bnfor \bnfpn{FuncArg} }\\
++\bnfprod{FuncArg}{\bnfpn{ByValue} \bnfpn{Type} \bnfpn{Id}}\\
++\bnfprod{ByValue}{\bnfts{val} \bnfor \bnfes}\\
++\bnfprod{ReturnStmt}{\bnfts{return } \bnfpn{ReturnValue}}\\
++\bnfprod{ReturnValue}{\bnfpn{Expr} \bnfor \bnfes}\\
++\end{bnf*}
++
++\begin{bnf*}
++\bnfprod{FuncCall}{\bnfpn{Id} \bnfts{ ( } \bnfpn{FuncCallArgs}\bnfts{ ) }}\\
++\bnfprod{FuncCallArgs}{ \bnfpn{FuncCallArg} \bnfor \bnfes}\\
++\bnfprod{FuncCallArg}{\bnfpn{Expr} \bnfts{ , } \bnfpn{FuncCallArg} \bnfor \bnfpn{Expr}} \\
++\bnfprod{ForEachStmt}{\bnfts{for ( } \bnfpn{Type} \bnfsp \bnfpn{Id} \bnfts{ in } \bnfpn{Expr} \bnfts{ ) } \bnfpn{Invariant} \bnfsp \bnfpn{Block}}\\
++\bnfprod{WhileStmt}{\bnfts{while}  \bnfts{ ( } \bnfpn{OrExpr} \bnfts{ ) } \bnfpn{Invariant} \bnfsp \bnfpn{Block}}\\
++\bnfprod{Invariant}{\bnfts{invariant } \bnfpn{OrExpr} \bnfsp \bnfpn{AssertMessage} \bnfor \bnfes }\\
++\bnfprod{IfStmt}{\bnfts{if} \bnfts{ ( } \bnfpn{OrExpr} \bnfts{ ) } \bnfpn{Block} \bnfpn{Else} }\\
++\bnfprod{Else}{ \bnfts{else} \bnfsp \bnfpn{ElseBody}  \bnfor \bnfes}\\
++\bnfprod{ElseBody}{\bnfpn{IfStmt} \bnfor \bnfpn{Block}}\\
++\bnfprod{Block}{\bnfts{ \{ } \bnfpn{FuncCmds} \bnfts{ \}}}\\
++\bnfprod{FuncCmd}{\bnfpn{VarDcl} \bnfor \bnfpn{Stmt}}\\
++\bnfprod{FuncCmds}{\bnfpn{FuncCmd} \bnfpn{FuncCmds} \bnfor \bnfes}\\
++\bnfprod{DefineList}{\bnfpn{Define} \bnfsp \bnfpn{DefineList} \bnfor \bnfes}\\
++\bnfprod{Define}{\bnfts{define ( } \bnfpn{Id} \bnfts{ ) \{ }  \bnfpn{DefineStmtList}   \bnfts{ \}} }\\
++\bnfprod{DefineStmtList}{\bnfpn{GraphAttrDcl} \bnfts{ ; } \bnfpn{DefineStmtList} \bnfor \bnfes}\\
++\bnfprod{AssertStmt}{\bnfts{assert } \bnfpn{OrExp} \bnfpn{AssertMessage}}\\
++\bnfprod{AssertMessage}{\bnfts{,} \bnfpn{StringLiteral} \bnfor \bnfes}\\
++\bnfprod{VertexSet}{\bnfts{V( }\bnfpn{Id} \bnfts{ )}}\\ %V(G)
++\bnfprod{EdgesSet}{\bnfts{E( }\bnfpn{Id} \bnfts{ )}}\\ %E(G)
++\bnfprod{EnumDcl}{\bnfts{enum \{} \bnfpn{EnumList} \bnfts{\}}}\\
++\bnfprod{EnumList}{\bnfpn{Type} \bnfpn{Id} \bnfts{;} \bnfpn{EnumList} \bnfor \bnfes}\\
++\bnfprod{Cardinality}{\bnfts{|}\bnfpn{Expr}\bnfts{|}}\\ % or order
++\bnfprod{NumEdges}{\bnfts{||}\bnfpn{Expr}\bnfts{||}}\\
++\bnfprod{Adjacent}{\bnfpn{Id}\bnfts{.adj[ } \bnfpn{Id} \bnfts{ ] }}\\
++\bnfprod{ElementInSet}{\bnfpn{Id}\bnfts{ in }\bnfpn{Id}}\\
++\end{bnf*}
++
++
+diff --git a/Statusseminar/sections/begreber.tex b/Statusseminar/sections/begreber.tex
+new file mode 100644
+index 0000000..e69de29
+diff --git a/Statusseminar/sections/bnf.tex b/Statusseminar/sections/bnf.tex
+new file mode 100644
+index 0000000..f39bacf
+--- /dev/null
++++ b/Statusseminar/sections/bnf.tex
+@@ -0,0 +1,87 @@
++\begin{bnf*}
++\bnfprod{Prog}{\bnfpn{Cmds}}\\
++\bnfprod{Cmds}{\bnfpn{Cmd}\bnfpn{Cmds} \bnfor \bnfes}\\
++\bnfprod{Cmd}{\bnfpn{Stmt}\bnfor\bnfpn{Dcl}}\\
++\bnfprod{Dcl}{\bnfpn{VarDcl} \bnfor \bnfpn{FuncDcl} \bnfor \bnfpn{EnumDcl}}\\
++\bnfprod{VarDcl}{\bnfpn{Type} \bnfsp \bnfpn{Id} \bnfsp \bnfpn{InitOpt} \bnfts{ ; } }\\
++\bnfprod{InitOpt}{\bnfts{ = }\bnfpn{Expr} \bnfor \bnfes }\\
++\bnfprod{Stmt}{\bnfpn{AssignStmt} \bnfts{ ; } \bnfor \bnfpn{ReturnStmt} \bnfts{ ; } \bnfor \bnfpn{WhileStmt} \bnfnlor \bnfpn{ForEachStmt} \bnfor \bnfpn{IfStmt} } \bnfor \bnfpn{AssertStmt} \bnfts{ ; } \\
++\bnfprod{ArithExpr}{\bnfpn{ArithExpr} \bnfpn{ArithOp} \bnfpn{Term} \bnfor \bnfpn{Term}}\\
++\bnfprod{ArithOp}{\bnfts{+} \bnfor \bnfts{-}}\\
++\bnfprod{Term}{\bnfpn{Term} \bnfsp\bnfpn{TermOp}\bnfsp \bnfpn{Factor} \bnfor \bnfpn{Factor}}\\
++\bnfprod{TermOp}{\bnfts{*} \bnfor \bnfts{/} \bnfor \bnfts{\%}}\\
++\bnfprod{Factor}{\bnfts{(}\bnfpn{ArithExpr}\bnfts{)}
++\bnfor \bnfpn{Field} \bnfor \bnfpn{FuncCall} \bnfor \bnfpn{IntLiteral} \bnfnlor \bnfpn{FloatLiteral} \bnfor \bnfpn{Cardinality} \bnfor \bnfpn{NumEdges}}\\
++\bnfprod{Id}{id}\\
++\bnfprod{Field}{\bnfpn{Id} \bnfor \bnfpn{Field}\bnfts{.}\bnfpn{Id}}\\
++\bnfprod{Expr}{\bnfpn{ArithExpr} \bnfor \bnfpn{OrExpr} \bnfor \bnfpn{GraphLit} \bnfor \bnfpn{EdgeLit} \bnfnlor \bnfpn{VertexLit} \bnfor \bnfpn{StringLiteral} \bnfor \bnfpn{CharLiteral}}\\
++%\bnfprod{LogicExpr}{\bnfpn{OrExpr} }\\
++\bnfprod{OrExpr}{\bnfpn{AndExpr} \bnfor \bnfpn{OrExpr} \bnfsp \bnfts{or}\bnfsp \bnfpn{AndExpr}}\\
++\bnfprod{AndExpr}{\bnfpn{NotExpr} \bnfor \bnfpn{AndExpr} \bnfsp\bnfts{and}\bnfsp \bnfpn{NotExpr}}\\
++\bnfprod{NotExpr}{\bnfts{not} \bnfsp \bnfpn{RelExpr} \bnfor \bnfpn{RelExpr}}\\
++\end{bnf*}
++
++\begin{bnf*}
++\bnfprod{RelExpr}{\bnfts{(} \bnfpn{OrExpr} \bnfts{)} \bnfor \bnfpn{BoolLiteral} \bnfor \bnfpn{Field} \bnfnlor \bnfpn{ArithExpr} \bnfpn{RelOp} \bnfpn{ArithExpr}\bnfor \bnfpn{ElementInSet}}\\
++\bnfprod{RelOp}{\bnfts{<} \bnfor \bnfts{<=} \bnfor \bnfts{>} \bnfor\bnfts{>=} \bnfor\bnfts{==} \bnfor \bnfts{!=} }\\
++\bnfprod{AssignStmt}{\bnfpn{Id} \bnfts{=} \bnfpn{ByValue} \bnfpn{Expr}}\\
++\bnfprod{GraphLit}{\bnfpn{GraphType}\bnfts{ \{ } \bnfpn{GraphStmtList} \bnfts{ \} }}\\
++\bnfprod{GraphType}{\bnfts{graph} \bnfor \bnfts{digraph}}\\
++\bnfprod{GraphStmtList}{\bnfpn{GraphStmt} \bnfts{ ; } \bnfpn{GraphStmtList} \bnfor \bnfes}\\
++\bnfprod{GraphStmt}{\bnfpn{EdgeStmt} \bnfor \bnfpn{VertexStmt} \bnfor \bnfpn{GraphAttrDcl}  } \\
++\bnfprod{EdgeStmt}{\bnfpn{Id} \bnfpn{EdgeOp} \bnfpn{EdgeStmtAux} \bnfpn{EdgeAttrList}}\\
++\bnfprod{EdgeStmtAux}{\bnfpn{Id} \bnfpn{EdgeOp} \bnfpn{EdgeStmtAux} \bnfor \bnfpn{Id} }\\
++\bnfprod{EdgeAttrList}{\bnfts{[ } \bnfpn{EdgeAttrAux} \bnfts{ ] }\bnfor \bnfes}\\
++\bnfprod{EdgeAttrAux}{\bnfpn{EdgeAttr} \bnfts{ , } \bnfpn{EdgeAttrAux} \bnfor \bnfpn{EdgeAttr}}\\
++\bnfprod{EdgeAttr}{\bnfpn{Id} \bnfts{ = } \bnfpn{EdgeAttrRHS}}\\
++\bnfprod{EdgeAttrRHS}{\bnfpn{Expr} \bnfor \bnfts{ \{ } \bnfpn{EdgeAttrVals} \bnfts{ \} } }\\
++%Expr eller EdgeAttrVal? 
++\bnfprod{EdgeAttrVals}{\bnfpn{Expr} \bnfts{ , } \bnfpn{EdgeAttrVals} \bnfor \bnfpn{Expr}}\\
++\bnfprod{EdgeOp}{\bnfts{-}\bnfts{-} \bnfor \bnfts{->} \bnfor \bnfts{<->}}\\
++\bnfprod{VertexStmt}{\bnfpn{Id}\bnfpn{SimpleAttrList}}\\
++%\bnfprod{GraphAttrAssign}{\bnfpn{Id} \bnfpn{GraphAttrStmts}}\\
++\bnfprod{GraphAttrDcl}{\bnfpn{VertEdgeKW} \bnfpn{VarDcl} }\\
++\bnfprod{VertEdgeKW}{\bnfts{vertex} \bnfor \bnfts{edge}}\\
++\bnfprod{Type}{\bnfts{int} \bnfor \bnfts{char} \bnfor \bnfts{bool} \bnfor \bnfts{float} \bnfor \bnfts{string} \bnfnlor \bnfts{vertex} \bnfor \bnfts{edge} \bnfor \bnfpn{GraphType}}\\
++\bnfprod{EdgeLit}{\bnfts{edge \{ } \bnfpn{Id}\bnfpn{EdgeOp}\bnfpn{Id} \bnfpn{SimpleAttrList} \bnfts{ \}} }\\
++\bnfprod{SimpleAttrList}{ \bnfts{[ } \bnfpn{SimpleAttr} \bnfts{ ]} \bnfor \bnfes}\\
++\bnfprod{SimpleAttr}{\bnfpn{AssignStmt} \bnfts{ , } \bnfpn{SimpleAttr} \bnfor \bnfpn{AssignStmt}}\\
++\bnfprod{VertexLit}{\bnfts{vertex \{ } \bnfpn{VertexStmt} \bnfts{  \} } }\\
++\bnfprod{FuncDcl}{\bnfpn{Type} \bnfpn{Id} \bnfts{ ( } \bnfpn{FuncArgs} \bnfts{ ) } \bnfpn{Define} \bnfpn{Block}}\\
++\bnfprod{FuncArgs}{\bnfpn{FuncArgList} \bnfor \bnfes}\\
++\bnfprod{FuncArgList}{\bnfpn{FuncArg} \bnfts{ , } \bnfpn{FuncArgList} \bnfor \bnfpn{FuncArg} }\\
++\bnfprod{FuncArg}{\bnfpn{ByValue} \bnfpn{Type} \bnfpn{Id}}\\
++\bnfprod{ByValue}{\bnfts{val} \bnfor \bnfes}\\
++\bnfprod{ReturnStmt}{\bnfts{return } \bnfpn{ReturnValue}}\\
++\bnfprod{ReturnValue}{\bnfpn{Expr} \bnfor \bnfes}\\
++\end{bnf*}
++
++\begin{bnf*}
++\bnfprod{FuncCall}{\bnfpn{Id} \bnfts{ ( } \bnfpn{FuncCallArgs}\bnfts{ ) }}\\
++\bnfprod{FuncCallArgs}{ \bnfpn{FuncCallArg} \bnfor \bnfes}\\
++\bnfprod{FuncCallArg}{\bnfpn{Expr} \bnfts{ , } \bnfpn{FuncCallArg} \bnfor \bnfpn{Expr}} \\
++\bnfprod{ForEachStmt}{\bnfts{for ( } \bnfpn{Type} \bnfsp \bnfpn{Id} \bnfts{ in } \bnfpn{Expr} \bnfts{ ) } \bnfpn{Invariant} \bnfsp \bnfpn{Block}}\\
++\bnfprod{WhileStmt}{\bnfts{while}  \bnfts{ ( } \bnfpn{OrExpr} \bnfts{ ) } \bnfpn{Invariant} \bnfsp \bnfpn{Block}}\\
++\bnfprod{Invariant}{\bnfts{invariant } \bnfpn{OrExpr} \bnfsp \bnfpn{AssertMessage} \bnfor \bnfes }\\
++\bnfprod{IfStmt}{\bnfts{if} \bnfts{ ( } \bnfpn{OrExpr} \bnfts{ ) } \bnfpn{Block} \bnfpn{Else} }\\
++\bnfprod{Else}{ \bnfts{else} \bnfsp \bnfpn{ElseBody}  \bnfor \bnfes}\\
++\bnfprod{ElseBody}{\bnfpn{IfStmt} \bnfor \bnfpn{Block}}\\
++\bnfprod{Block}{\bnfts{ \{ } \bnfpn{FuncCmds} \bnfts{ \}}}\\
++\bnfprod{FuncCmd}{\bnfpn{VarDcl} \bnfor \bnfpn{Stmt}}\\
++\bnfprod{FuncCmds}{\bnfpn{FuncCmd} \bnfpn{FuncCmds} \bnfor \bnfes}\\
++\bnfprod{DefineList}{\bnfpn{Define} \bnfsp \bnfpn{DefineList} \bnfor \bnfes}\\
++\bnfprod{Define}{\bnfts{define ( } \bnfpn{Id} \bnfts{ ) \{ }  \bnfpn{DefineStmtList}   \bnfts{ \}} }\\
++\bnfprod{DefineStmtList}{\bnfpn{GraphAttrDcl} \bnfts{ ; } \bnfpn{DefineStmtList} \bnfor \bnfes}\\
++\bnfprod{AssertStmt}{\bnfts{assert } \bnfpn{OrExp} \bnfpn{AssertMessage}}\\
++\bnfprod{AssertMessage}{\bnfts{,} \bnfpn{StringLiteral} \bnfor \bnfes}\\
++\bnfprod{VertexSet}{\bnfts{V( }\bnfpn{Id} \bnfts{ )}}\\ %V(G)
++\bnfprod{EdgesSet}{\bnfts{E( }\bnfpn{Id} \bnfts{ )}}\\ %E(G)
++\bnfprod{EnumDcl}{\bnfts{enum \{} \bnfpn{EnumList} \bnfts{\}}}\\
++\bnfprod{EnumList}{\bnfpn{Type} \bnfpn{Id} \bnfts{;} \bnfpn{EnumList} \bnfor \bnfes}\\
++\bnfprod{Cardinality}{\bnfts{|}\bnfpn{Expr}\bnfts{|}}\\ % or order
++\bnfprod{NumEdges}{\bnfts{||}\bnfpn{Expr}\bnfts{||}}\\
++\bnfprod{Adjacent}{\bnfpn{Id}\bnfts{.adj[ } \bnfpn{Id} \bnfts{ ] }}\\
++\bnfprod{ElementInSet}{\bnfpn{Id}\bnfts{ in }\bnfpn{Id}}\\
++\end{bnf*}
++
++
+diff --git a/Statusseminar/sections/cfg.tex b/Statusseminar/sections/cfg.tex
+new file mode 100644
+index 0000000..d6c8989
+--- /dev/null
++++ b/Statusseminar/sections/cfg.tex
+@@ -0,0 +1,60 @@
++
++\subsection{Beskrivelse af syntaks}
++
++Der er til sproget udarbejdet en \gls{cfg} i \gls{bnf}, der kan ses i afsnit \ref{sec:cfg_formelsyntaks}.
++Sproget er et imparativt programmeringssprog, med en syntax der minder om den fra C.
++Foruden dette indeholder den grafer som førstehånds objekter, disse erklæres med en syntaks der minder om DOT fra Graphviz, se \cite{Gansner00}.
++Nu vil de forskellige sproglige konstruktioner som grammatikken understøtter blive præsenteret.
++
++Grammatikken understøtter følgende typer ved de specificerede nøgleord: heltal (\texttt{int}), tegn (\texttt{char}), boolske typer (\texttt{bool}), flydende komma tal (\texttt{float}), graf knuder (\texttt{vertex}), graf kanter (\texttt{edge}) samt uorienterede og orienterede grafer (hhv. \texttt{graph} og \texttt{digraph}).
++Der er defineret aritmetiske operationer på heltal og flydende komma tal.
++De muligt aritmetiske operationer i sproget, angivet ved infix notation, er: Addition (\texttt{+}), subtraktion (\texttt{-}), multiplikation (\texttt{*}), division (\texttt{/}) og modulo (\texttt{\%}). 
++Der er også et subset af de aritmetiske operationer defineret mellem grafer og knuder, kanter eller grafer.
++De mulige aritmetiske operationer er addition og subtraktion.
++
++Grafer defineres i sproget ved en DOT-agtig syntaks, jf. afsnit \ref{sec:stateoftheart_dot}, med tilføjelse af en operator mellem kanter, \texttt{<->}, til at indikere at en kant går begge veje. 
++Attributter på grafer erklæres på samme måde som variable, men præfikses med \texttt{vertex} og \texttt{edge} for attributter på hhv. knuder og kanter, se linje \ref{lstline:specifikation_cfg_grafeksempel_attrdclstart}-\ref{lstline:specifikation_cfg_grafeksempel_attrdclend} i listing \ref{lst:specifikation_cfg_grafeksempel}. 
++Attributter kan tildeles værdier enten som standardværdier ved erklæring eller ved en attribut-liste indkapslet i \texttt{[ ]}.
++I funktioner er det muligt at erklære nye attributter på en graf ved \texttt{define} syntaksen, der kan ses i listing \ref{lst:specifikation_cfg_grafattributeksempel}. 
++I et \texttt{define}-udtryk erklæres nye attributter på samme vis som i erklæringen af en graf, og attributterne kan derefter benyttes, se linje \ref{lstline:specifikation_cfg_grafattributeksempel_assign}.
++Knude- og kantmængden af en graf G kan tilgås ved hhv. \texttt{V(G)} og \texttt{E(G)}, tilsvarende den matematiske notation. 
++Ligeledes kan antallet af knuder og kanter tilgås ved hhv. \texttt{|G|} og \texttt{||G||} for en graf G. 
++
++Sproget indeholder procedurer og kontrolstrukturer, der i høj grad minder om tilsvarende fra C, navnligt \texttt{if} og \texttt{while}\todo{Opdater, hvis switch inkluderes}, samt et \texttt{for}-udtryk, der semantisk svarer til \texttt{foreach} fra \CS/. 
++Alle kontrolstrukturer kræver eksplicitte blokke for at undgå dangling-else problemet. %, jf. afsnit \ref{sec:problemanalyse_parserteori_problematikker}\tanker{Dokumenteres problemet? Er det nødvendigt at nævne dangling else, eller skal vi undlade at nævne det?}.
++Lovlig og ulovlig brug af kontrolstrukturer ses i listing hhv. \ref{lst:specifikation_cfg_kontrolstrukturer_lovlig} og \ref{lst:specifikation_cfg_kontrolstrukturer_ulovlig}.
++%På løkkerne, dvs. \texttt{while} og \texttt{for}, er det desuden muligt at specificere løkke-invarianter, der tjekkes før hver iteration af løkken og efter løkken terminerer\tanker{Er usikker på, hvad præcis invarianter i sproget skal gøre, hvilket gør det svært for mig at komme med et godt eksempel \textit{//Nikolaj}}. 
++Et eksempel på syntaksen for \texttt{for}-løkker kan ses i listing \ref{lst:specifikation_cfg_grafattributeksempel} på linje \ref{lstline:specifikation_cfg_forloopeksempel}.
++
++\begin{figure*}
++	\lstinputlisting[caption={Eksempel på graferklæring i sproget.},label={lst:specifikation_cfg_grafeksempel},escapechar=¤]{listings/knud/graphdclexample.tex}
++\end{figure*}
++
++\begin{figure*}
++	\lstinputlisting[caption={Eksempel på tilføjelse af nye attributter},label={lst:specifikation_cfg_grafattributeksempel},escapechar=¤]{listings/knud/graphattributeaddition.tex}
++\end{figure*}
++
++\begin{figure*}
++	\begin{minipage}[b]{0.45\textwidth}
++		\lstinputlisting[caption={Legal syntaks: Eksplicit blok.},label={lst:specifikation_cfg_kontrolstrukturer_lovlig},escapechar=¤]{listings/knud/blocklegal.tex}
++	\end{minipage}
++	\hfill
++	\begin{minipage}[b]{0.45\textwidth}
++		\lstinputlisting[caption={Illegal syntaks: Ingen blok.},label={lst:specifikation_cfg_kontrolstrukturer_ulovlig},escapechar=¤]{listings/knud/blockillegal.tex}
++	\end{minipage}
++\end{figure*}
++
++%\begin{figure*}
++%	\lstinputlisting[caption={Eksempel på løkke-invariant og \texttt{for}-løkke}, label={lst:specifikation_cfg_invariant},escapechar=¤]{listings/knud/invariant.tex}
++%\end{figure*}
++
++\begin{table}
++	\centering
++	\input{figures/tables/lexemes.tex}
++	\caption{Regulære udtryk for tokens.}
++	\label{tab:specifikation_cfg_lexemes}
++\end{table}
++
++\clearpage
++\subsection{Formel syntaks}\label{sec:cfg_formelsyntaks}
++\input{sections/bnf.tex}
+\ No newline at end of file
+diff --git a/Statusseminar/sections/interessenter.tex b/Statusseminar/sections/interessenter.tex
+new file mode 100644
+index 0000000..e69de29
+diff --git a/Statusseminar/sections/kriterier.tex b/Statusseminar/sections/kriterier.tex
+new file mode 100644
+index 0000000..7f85aea
+--- /dev/null
++++ b/Statusseminar/sections/kriterier.tex
+@@ -0,0 +1,47 @@
++Dette afsnit vil præsentere designkriterier for sproget samt funktionelle krav. 
++
++\subsection{Designkriterier}
++
++\citeauthor{Sebesta2016} fremsætter tre overordnede kriterier for programmeringssprog: Læsbarhed, skrivbarhed og pålidelighed\cite{Sebesta2016}. 
++Læsbarheden er et mål for, hvor enkelt det er at læse og forstå kode i et sprog\cite{Sebesta2016}.
++Skrivbarhed beskriver, hvor hurtigt, det er at skrive korrekt kode i et givent sprog\cite{Sebesta2016}.
++Pålidelighed er, om det er let at undgå eller håndtere fejl i et givet sprog\cite{Sebesta2016}.
++Læsbarhed og skrivbarhed prioriteres højere end pålidelighed, da sprogets formål er prototypeudvikling og ikke produktionsmiljøer, jf. problemformuleringen.
++
++\citeauthor{Sebesta2016} beskriver desuden karakteristika, der fungerer som underpunkter for hver af disse kriterier. 
++Disse karakteristika er prioriteret ift. dette projekt i tabel \ref{tab:kriterier_sprogkriterier}.
++Det antages, at læseren er bekendt med, hvad disse karakteristika handler om. \tiljane{}
++
++
++\begin{table}
++	\begin{tabularx}{\textwidth}{Xcccc}
++		\toprule
++		\textit{\textbf{Karakteristika}} & Meget vigtig & Vigtig & Mindre vigtig & Irrelevant\\
++		\midrule
++		Simplicitet & \tblX & & &  \\
++		Orgotonalitet & & \tblX & & \\
++		Datatyper & \tblX & & & \\
++		Design af syntaks & \tblX & & & \\
++		Abstraktion & \tblX & & & \\
++		Udtrykkelighed & & & \tblX & \\
++		Typetjek & \tblX & & & \\
++		Fejlhåndtering & & & & \tblX \\
++		Håndtering af aliasing  & & & & \tblX \\		
++		\bottomrule
++	\end{tabularx}
++	\caption{Prioritering af designkriterier\cite[31]{Sebesta2016}.}
++	\label{tab:kriterier_sprogkriterier}
++\end{table}
++
++\subsection{Funktionelle krav}
++
++Sproget skal indeholde simpel aritmetik med simple typer som heltal og kommatal, dvs. addition, subtraktion, multiplikation, division og modulo. 
++Desuden skal sproget indeholde procedurer og kald af disse, samt selektive og iterative kontrolstrukturer, navnligt \texttt{if}, \texttt{while} og \texttt{for} each. 
++Til disse kontrolstrukturer skal der være logiske udtryk, der returnerer en seperat booleansk datatype. 
++Derudover skal der være variabler samt tekstuelle datatyper.
++Da sproget skal kunne bruges til at arbejde med grafer skal grafer selvsagt også være en datatype, både uorienterede og orienterede grafer.
++Tilhørende disse skal der være en dedikeret type til knuder og til kanter, en enkelt initialiering af både grafer, knuder og kanter, og simple grafoperationer såsom addition og subtraktion skal også understøttes.
++Derudover skal der være en fornuftig måde at understøtte attributter på grafer på, da mange standardalgoritmer til grafer benytter disse, jf. \citeauthor{CLRS2009}\cite{CLRS2009}.
++
++Nogle ''should have'' krav inkluderer muligheden for operatorer til at udhente antal kanter eller knuder fra en graf eller at udhente naboliste eller nabomatrice repræsentationerne af en graf. 
++Derudover er et ønske også at implementere enumererede typer og dertil en \texttt{switch} kontrolstruktur samt andre, mere specifikke grafoperationer. 
+\ No newline at end of file
+diff --git a/Statusseminar/sections/maalgruppe.tex b/Statusseminar/sections/maalgruppe.tex
+new file mode 100644
+index 0000000..847ff07
+--- /dev/null
++++ b/Statusseminar/sections/maalgruppe.tex
+@@ -0,0 +1,25 @@
++% Intro
++I dette afsnit vil målgruppen for projektet blive defineret, og de væsentligste karakteristika for denne målgruppe undersøges.
++Formålet med at undersøge målgruppen er at definere og vægte krav, da kravene til et programmeringssprog afhænger af, hvem der skal anvende det.
++
++% Analyse
++%Jf. kapitel \ref{ch:intro}\todo{Tjek ref efter flettet sammen} er formålet med sproget at gøre det let at lave prototyper af grafalgoritmer.
++Formålet med sproget er at gøre det let at lave prototyper af grafalgoritmer.
++Det betyder, at målgruppen for sproget er personer, som udvikler eller skriver grafalgoritmer.
++Det kunne eksempelvis være:
++
++\begin{itemize}
++	\item Softwareudviklere, som udvikler grafalgoritmer til at løse praktiske problemer,
++	\item Matematikere, som bruger grafteori på et teoretisk plan,
++	\item Dataloger, som kan løse både teoretiske og praktiske problemer.
++\end{itemize}
++
++Et fælles kendetegn for disse personer er, at de har kendskab til programmering.
++Dette betyder, at disse er bekendt med grundlæggende datalogiske begreber og har erfaring i at skrive programmer efter en fast syntaks\cite{MatStudieordning}, og såfremt et sprog ligner andre sprog, som målgruppen kender, bør læringskurven for programmeringssproget være forholdsvis lav. 
++Desuden antages det, at disse har en viden om grafteori, da emnet er grundlæggende for datalogi, og matematik\cite{Rosen2013}.
++Derfor skal den korrekte terminologi anvendes inden for emnet, således det er muligt for brugeren at udtrykke sig konkret indenfor terminologien.
++Derudover er det en mulighed at anvende den matematiske notation for sproglige konstruktioner, som opererer på grafer.
++Eksempelvis for en graf $ G $ er $ |G| $ antallet af knuder, og $ ||G|| $ antallet af kanter i $ G $ \cite{Chartrand2016}.
++
++% Opsumering
++I dette afsnit er målgruppen for dette projekt blevet beskrevet, og hvilke muligheder dette giver for sprogets syntaks, er undersøgt.
+\ No newline at end of file
+diff --git a/Statusseminar/sections/problemformulering.tex b/Statusseminar/sections/problemformulering.tex
+new file mode 100644
+index 0000000..211cef3
+--- /dev/null
++++ b/Statusseminar/sections/problemformulering.tex
+@@ -0,0 +1,23 @@
++I dette afsnit vil problemformuleringen blive præsenteret med begrundelse for underspørgsmålene.
++Som præsenteret i afsnit \todo{ref} så er det overordnede mål med sproget at understøtte udvikling og prototyping af grafalgoritmer.
++Dette leder op til det overordnede spørgsmål i problemformuleringen:
++\begin{quote}
++	\textbf{\textit{Hvordan udvikles et sprog der understøtter udvikling og prototyping af grafalgoritmer?}}
++\end{quote}
++For nemmere at kunne besvare det overordnede spørgsmål er der formuleret en række underspørgsmål.
++I afsnit \todo{ref} blev vigtigheden af læselighed og skrivbarhed af sprog udforsket, og på baggrund af dette afsnit er følgende underspørgsmål blevet fremsat:
++\begin{quote}
++	\textit{Hvordan kan sprogets syntaks skrivbart og læseligt understøtte grafer og grafalgoritmer?}
++\end{quote}
++På baggrund af afsnit \ref{sec:problemanalyse_maalgruppe} fremgår det at den primære målgruppe for projektet er softwareudviklere, matematikere og dataloger.
++Denne målgruppe har kendskab til grafer i en matematisk kontekst, og har erfaring med at programmere, jf. afsnit \ref{sec:problemanalyse_maalgruppe}.
++Derfor vil det være fordelagtigt hvis sproget dels trækker på syntaks fra matematikken, og dels syntaks fra eksisterende programmeringssprog.
++Dette har ledt til følgende underspørgsmål:
++\begin{quote}
++	\textit{Hvordan kan sproget understøtte eksisterende koncepter for bearbejdning af grafer, både fra matematikken samt eksisterende programmeringssprog til repræsentation af grafer?}
++\end{quote}
++Da sproget skal understøtte udvikling og prototyping af grafalgoritmer, er det også vigtigt at der bliver givet beskrivende fejlbeskeder.
++Hvilket leder til underspørgsmålet:
++\begin{quote}
++	\textit{Hvordan kan sproget sikre at fejlbeskeder bliver beskrivende og fyldestgørende?}
++\end{quote}
+\ No newline at end of file
+diff --git a/Statusseminar/sections/programeksempler.tex b/Statusseminar/sections/programeksempler.tex
+new file mode 100644
+index 0000000..64f1dc1
+--- /dev/null
++++ b/Statusseminar/sections/programeksempler.tex
+@@ -0,0 +1,9 @@
++Herunder følger nogle programeksempler skrevet i sprogets syntaks.
++
++\subsection{Eksempel på BFS}
++
++\input{listings/kode_eksempler/BFS.tex}
++
++\subsection{Eksempel på beregning af Euler-kreds}
++
++\input{listings/kode_eksempler/Euler.tex}
+diff --git a/Statusseminar/sections/stateoftheart.tex b/Statusseminar/sections/stateoftheart.tex
+new file mode 100644
+index 0000000..8e0db15
+--- /dev/null
++++ b/Statusseminar/sections/stateoftheart.tex
+@@ -0,0 +1,100 @@
++%Metatekst
++%\tanker[inline]{Afsnit bør omstruktureres, så fordele og ulemper står sammen efterfulgt af samlet tekst.}
++Til at repræsentere og arbejde med grafer har en programmør flere muligheder afhængigt af hvilket programmeringssprog der benyttes.
++Eksempler herpå vil nu blive gennemgået for sprogene C, GP og DOT.
++Formålet er at undersøge, hvilke funktionaliteter et nyt sprog bør have, samt hvilke der ikke er nødvendige.
++
++\subsection{Programmering med grafer i C}
++%Intro
++I C vil en graf blive repræsenteret i form af en nabomatrix eller nabolister.
++Dette kan repræsenteres med \texttt{struct}-datatypen.
++Da grafrepræsentationen med \texttt{struct}-datatypen skal defineres, betyder det, at programmøren bestemmer den interne repræsentation, hvilket ikke er i overensstemmelse med det abstraktionsniveau, grafer afspejler.
++%Fordele
++\subsubsection*{Fordele ved at bruge C til grafer}
++\begin{itemize}
++	\item God ydelse\cite{LanguageBenchmark}.
++	\item Høj platformsuafhængighed\cite{Sebesta2016}.
++	\item Fleksibilitet ved at bestemme den interne repræsentation.
++\end{itemize}
++
++%Ulemper
++\subsubsection*{Ulemper ved at bruge C til grafer}
++I bilag \ref{lst:app_cgraph} er der et eksempel på en simpel implementering af en graf og funktionalitet til at tilføje kanter til den i C. 
++Det kræver meget kode at repræsentere en simpel graf i C.
++Der er ingen generel syntaks for repræsentation af grafer, og en programmør er derfor nød til konstruere repræsentationen selv, hvilket medfører:
++\begin{itemize}
++	\item Reduceret produktivitet.
++	\item Lavere abstraktionsniveau.
++\end{itemize}
++
++Ved at benytte C til at repræsentere grafer, vil fordelene være høj ydelse og fleksibilitet, da programmøren har kontrol over den interne repræsentation og kan derved formindske overhead. 
++Disse fordele er dog på bekostning af reduceret produktivitet, da alle aspekter skal skrives manuelt, samt lavere abstraktionsniveau, hvilket resulterer i, at det måske er sværere at forstå og løse en given problemstilling.
++%Det er muligt at anvende et bibliotek til at håndtere konstruktionen af grafer\cite{North2014}.
++%Dette er dog stadig et lavere abstraktionsniveau end grafteori, da programmøren f.eks. skal tænke over pointere.
++%Andre programmeringssprog med højere abstraktionsniveau, såsom Java eller \CS/, kan afhjælpe nogle af problemerne, ved eksempelvis bedre fejlhåndtering end fejlkoder, men skal stadig benytte en eksplicit repræsentation af graferne. 
++%\todo[inline]{Syntes der bliver brugt for lidt energi på biblioteket. Hvorfor er der ikke et kodeeksempel på dette, og hvilke fordele/ulemper er der ved det? Hvis Java eller CS fikser de nævnte problemer, hvorfor er de så ikke overvejet nærmere?}
++%\todo[inline]{Synes det vil være for meget i et state of the art afsnit at gå i dybden med bibliotekerne, og C afsnittet er i forvejen ret langt. Vil dog også mene at den sidste pointe med Java og CS ikke er afsluttet. Jeg stemmer for at det bliver fjernet, da hvis vi begynder at beskrive Java og CS tilgang til graf programmering har vi efterhånden ret mange eksisterende løsninger.}
++
++\subsection{GP}
++%\todo[inline]{Afsnit savner en pæn figur af GP, så man kan se, hvordan det ser ud.}
++GP er et graforienteret sprog, som fokuserer på visualisering af grafer og problemløsning med grafer, eksempelvis transitiv lukning og den inverse graf\cite{Plump2009}.
++GP har en grafisk brugergrænseflade, som gør det nemmere for programmøren at lave grafer og abstrahere fra den interne repræsentation\cite{Plump2009}.
++Instruktioner i GP kaldes transformationer, som ændrer på en graf i henhold til kildekoden, hvilket sker via en brugergrænseflade\cite{Plump2009}. Denne brugergrænseflade er med til at skabe en visuelt billede af grafen, som bliver konstrueret.
++%\todo{Hvornår sker interfacet med et program med andet end en brugergrænseflade? Hvad er der så specielt ved GP's ''grafiske'' brugergrænse flade i forhold til at bruge et tekst editor eller et IDE? Denne visuelle brugergrænseflade kunne måske også vises i rapporten.}.
++
++%Fordele
++\subsubsection*{Fordele ved at bruge GP til grafer}
++
++\begin{itemize}
++	\item Visuel brugergrænseflade.
++	\item Højt abstraktionsniveau.
++	\item Programmering med grafer som en serie af transformationer.
++\end{itemize}
++%Ulemper
++\subsubsection*{Ulemper ved at bruge GP til grafer}
++\begin{itemize}
++	\item Visuel brugergrænseflade skalerer dårligt\cite{GP2Issues}.
++	\item Fejl i compileren\cite{GP2Issues}.
++	\item Ingen standardimplementation af gængse grafalgoritmer\cite{Plump2009}.
++	\item Besværlig generalisering af algoritmer.
++\end{itemize}
++
++Den visuelle brugergrænseflade gør det nemt for programmøren at visualisere en graf og algoritmerne, hvilket medfører at abstraktionsniveauet bliver højere. 
++Desuden tvinger programmeringssproget programmøren til at tænke på problemstillingen som en serie af graftransformationer, hvilket er mere naturlig for grafer, kontra eksemplet fra C, som kan ses i listing \ref{lst:app_cgraph}. 
++Det gør abstraktionsniveauet højt, så programmøren ikke behøver at tænke på den interne repræsentation.
++Problemet er midlertidigt, at sproget er forholdsvis nyt\cite{Plump2009}, så der mangler standardimplementationer, og compileren er ikke færdig.
++Den visuelle brugergrænseflade skalerer også dårligt for store grafer, og GP indeholder ikke førsteklassesfunktioner eller funktionspointere, hvilket gør det besværligt at lave generelle algoritmer\cite{Plump2009}.
++%Gammel formulering; begge pointer er redundante pt.
++%Sidst er sproget meget specifikt, så det kræver en grafisk brugergrænseflade, og det er svært at generalisere algoritmer\todo{Citation needed}, hvoraf sidstnævnte vil være en fordel ved f.eks. Dijkstras algoritme, jf. afsnit \ref{sec:problemanalyse_graphproblems_shortestpath}\todo{Ref til Dijkstra afsnit når merged}, hvor vægten på en kant kan opfattes som en variabel på hver kant eller en funktion for vægten mellem to knuder.
++
++\subsection{DOT}\label{sec:stateoftheart_dot}
++DOT er et programmeringssprog, som bruges til at beskrive konstruktion og visualisering af grafer.  
++DOT er et deklarativt sprog, hvor grafen beskrives med knuder, kanter og subgrafer samt attributer på førnævnte.
++En fortolker kan på baggrund af disse konstruktioner tegne en graf, som repræsenterer det ønskede.
++Ved at anvende kode til at beskrive visualiseringen, behøves der ikke erfaring med grafiske designværktøjer for at kunne tegne en graf.
++DOT er begrænset til kun at beskrive grafer, og oversættes derfor ikke til nogen form for eksekverbar kode\cite{DOTGraphs}. 
++
++Et eksempel på DOT syntaksen kan ses i bilag \ref{app:DOT}.
++% Fordele og ulemper ved grafer
++\subsubsection*{Fordele ved at bruge DOT til grafer}
++DOT er som nævnt ovenfor et sprog beregnet til konstruktion og visualsering af grafer.
++Syntaksen er derfor god til at beskrive grafer, hvilket kan benyttes i et programmeringssprog, som bearbejder grafer.
++\begin{itemize}
++	\item God visualisering af grafer.
++	\item God syntaks til definitioner af grafer og attributter.
++\end{itemize}
++
++\subsubsection*{Ulemper ved at bruge DOT til grafer}
++DOT er selvsagt ikke egnet til programmering i sig selv, da det ikke producerer eksekverbar kode, og derfor håndterer sproget ikke problemstillinger ved operationer på grafer.
++Syntaksen kan, på trods af dets kortfattethed, være svær at overskue ved større grafer.
++Det kan eksempelvis være svært at afgøre, om to knuder er forbundet, ved blot at kigge på koden. DOT har dog mere fokus på det grafiske output hvilket kan have negative konsekvenser for større grafer.
++Dette kaldes også for lav læsbarhed.
++\begin{itemize}
++	\item Ingen eksekverbar kode.
++	\item Lav læsbarhed ved større grafer.
++\end{itemize}
++
++%Opsummering
++Syntaksen ved DOT gør det naturligt at beskrive grafer, men da DOT ikke bruges til ekskverbar kode, kan der være problemstillinger, sproget ikke håndterer.
++Derfor kan elementer fra DOTs syntaks benyttes og udvides med ønskede funktionaliteter til et sprog, der bearbejder grafer.
++\todo[inline]{Mangler en generel opsummering der nævner hvilke ting vi så vil have med i vores sprog.}
+\ No newline at end of file
+diff --git a/Statusseminar/sections/statusseminar.tex b/Statusseminar/sections/statusseminar.tex
+new file mode 100644
+index 0000000..fdb4807
+--- /dev/null
++++ b/Statusseminar/sections/statusseminar.tex
+@@ -0,0 +1,18 @@
++\chapter{Problemanalyse}
++\section{Målgruppeanalyse}\label{sec:problemanalyse_maalgruppe}
++\input{sections/maalgruppe.tex}
++
++\section{State of the art}
++\input{sections/stateoftheart.tex}
++
++\section{Problemformulering}
++\input{sections/problemformulering.tex}
++
++\section{Løsningskriterier}
++\input{sections/kriterier.tex}
++
++\section{Sprogets syntaks}
++\input{sections/cfg.tex}
++
++\section{Programeksempler}
++\input{sections/programeksempler.tex}
+diff --git a/Statusseminar/setup/acronyms.tex b/Statusseminar/setup/acronyms.tex
+new file mode 100644
+index 0000000..f17394d
+--- /dev/null
++++ b/Statusseminar/setup/acronyms.tex
+@@ -0,0 +1,4 @@
++\newacronym{dag}{DAG}{directed acyclic graph}
++\newacronym{mst}{MST}{minimum-weight spanning tree}
++\newacronym{bnf}{BNF}{Backus-Naur form}
++\newacronym{cfg}{CFG}{Kontekst-fri grammatik}
+diff --git a/Statusseminar/setup/hyphenations.tex b/Statusseminar/setup/hyphenations.tex
+new file mode 100644
+index 0000000..b9249b5
+--- /dev/null
++++ b/Statusseminar/setup/hyphenations.tex
+@@ -0,0 +1,6 @@
++% see, e.g., http://en.wikibooks.org/wiki/LaTeX/Formatting#Hyphenation
++% for more information on word hyphenation
++\hyphenation{ex-am-ple hy-phen-a-tion short}
++\hyphenation{long la-tex}
++\hyphenation{til-føjet}
++\hyphenation{ingrediens-mængde}
+diff --git a/Statusseminar/setup/macros.tex b/Statusseminar/setup/macros.tex
+new file mode 100644
+index 0000000..03bc206
+--- /dev/null
++++ b/Statusseminar/setup/macros.tex
+@@ -0,0 +1,195 @@
++%  A simple AAU report template.
++%  2015-05-08 v. 1.2.0
++%  Copyright 2010-2015 by Jesper Kjær Nielsen <jkn@es.aau.dk>
++%
++%  This is free software: you can redistribute it and/or modify
++%  it under the terms of the GNU General Public License as published by
++%  the Free Software Foundation, either version 3 of the License, or
++%  (at your option) any later version.
++%
++%  This is distributed in the hope that it will be useful,
++%  but WITHOUT ANY WARRANTY; without even the implied warranty of
++%  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++%  GNU General Public License for more details.
++%
++%  You can find the GNU General Public License at <http://www.gnu.org/licenses/>.
++%
++%
++%
++% see, e.g., http://en.wikibooks.org/wiki/LaTeX/Customizing_LaTeX#New_commands
++% for more information on how to create macros
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Macros for text simplifying
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++\def\OOAD/{OOA\&D}
++\newcommand{\janerettet}[2][]{\todo[color=YellowGreen, #1]{#2}}
++\newcommand{\jane}[2][]{\todo[color=red, #1]{#2}}
++\newcommand{\tiljane}[2][]{\todo[color=cyan, #1]{\textbf{Til opponentgruppe: }#2}}
++\newcommand{\tanker}[2][]{\todo[color=Orchid, #1]{#2}}
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Macros for interviewcitation
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++\newcommand{\llabel}[1]{\hypertarget{llineno:#1}{\linelabel{#1}}}
++\newcommand{\lref}[1]{\hyperlink{llineno:#1}{\ref*{#1}}}
++\newcommand{\lpageref}[1]{\hyperlink{llineno:#1}{\pageref*{#1}}}
++
++%Single line labels
++\newcommand{\interviewlabel}[2]{\llabel{lne:#1_#2}}
++
++%Single line references
++\newcommand{\interviewref}[2]{(\makefirstuc{#1}, L. \lref{lne:#1_#2})}
++
++%Multiline labels
++\newcommand{\interviewlabelb}[2]{\llabel{lne:#1_#2start}}
++\newcommand{\interviewlabele}[2]{\llabel{lne:#1_#2slut}}
++
++
++%Multiline references
++\newcommand{\interviewrefr}[2]{(\makefirstuc{#1}, L. \lref{lne:#1_#2start}-\lref{lne:#1_#2slut})}
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Macros for the titlepage
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++%Creates the aau titlepage
++\newcommand{\aautitlepage}[3]{%
++  {
++    %set up various length
++    \ifx\titlepageleftcolumnwidth\undefined
++      \newlength{\titlepageleftcolumnwidth}
++      \newlength{\titlepagerightcolumnwidth}
++    \fi
++    \setlength{\titlepageleftcolumnwidth}{0.5\textwidth-\tabcolsep}
++    \setlength{\titlepagerightcolumnwidth}{\textwidth-2\tabcolsep-\titlepageleftcolumnwidth}
++    %create title page
++    \thispagestyle{empty}
++    \noindent%
++    \begin{tabular}{@{}ll@{}}
++      \parbox{\titlepageleftcolumnwidth}{
++        \iflanguage{danish}{%
++          \includegraphics[width=\titlepageleftcolumnwidth]{figures/aau_logo_da}
++        }{%
++          \includegraphics[width=\titlepageleftcolumnwidth]{figures/aau_logo_en}
++        }
++      } &
++      \parbox{\titlepagerightcolumnwidth}{\raggedleft\sf\small
++        #2
++      }\bigskip\\
++       #1 &
++      \parbox[t]{\titlepagerightcolumnwidth}{%
++      \textbf{Abstract:}\bigskip\par
++        \fbox{\parbox{\titlepagerightcolumnwidth-2\fboxsep-2\fboxrule}{%
++          #3
++        }}
++      }\\
++    \end{tabular}
++    \vfill
++    \iflanguage{danish}{%
++      \noindent{\footnotesize\emph{Rapportens indhold er frit tilgængeligt, men offentliggørelse (med kildeangivelse) må kun ske efter aftale med forfatterne.}}
++    }{%
++      \noindent{\footnotesize\emph{The content of this report is freely available, but publication (with reference) may only be pursued due to agreement with the author.}}
++    }
++    \clearpage
++  }
++}
++
++%Create english project info
++\newcommand{\englishprojectinfo}[8]{%
++  \parbox[t]{\titlepageleftcolumnwidth}{
++    \textbf{Title:}\\ #1\bigskip\par
++    \textbf{Theme:}\\ #2\bigskip\par
++    \textbf{Project Period:}\\ #3\bigskip\par
++    \textbf{Project Group:}\\ #4\bigskip\par
++    \textbf{Participant(s):}\\ #5\bigskip\par
++    \textbf{Supervisor(s):}\\ #6\bigskip\par
++    %\textbf{Copies:} #7\bigskip\par
++    \textbf{Page Numbers:} \pageref{pg:lastpage}\bigskip\par
++    \textbf{Date of Completion:}\\ #8
++  }
++}
++
++%Create danish project info
++\newcommand{\danishprojectinfo}[8]{%
++  \parbox[t]{\titlepageleftcolumnwidth}{
++    \textbf{Titel:}\\ #1\bigskip\par
++    \textbf{Tema:}\\ #2\bigskip\par
++    \textbf{Projektperiode:}\\ #3\bigskip\par
++    \textbf{Projektgruppe:}\\ #4\bigskip\par
++    \textbf{Deltagere:}\\ #5\bigskip\par
++    \textbf{Vejleder:}\\ #6\bigskip\par
++    %\textbf{Oplagstal:} #7\bigskip\par
++    \textbf{Sidetal:} \pageref{pg:lastpage}\bigskip\par
++    \textbf{Afleveringsdato:}\\ #8
++  }
++}
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% An example environment
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++\theoremheaderfont{\normalfont\bfseries}
++\theorembodyfont{\normalfont}
++\theoremstyle{break}
++\def\theoremframecommand{{\color{gray!50}\vrule width 5pt \hspace{5pt}}}
++\newshadedtheorem{exa}{Example}[chapter]
++\newenvironment{example}[1]{%
++		\begin{exa}[#1]
++}{%
++		\end{exa}
++}
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Math operators
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++\newcommand{\supnorm}[1]{\left\Vert #1 \right\Vert_{\infty}}
++\newcommand{\norm}[1]{\left\Vert #1 \right\Vert}
++\newcommand{\absut}[1]{\left\vert #1 \right\vert}
++\newcommand{\paren}[1]{\left( #1 \right)}
++\newcommand{\karen}[1]{\left[ #1 \right]}
++\newcommand{\ball}[2]{B_{#1}\left(#2\right)}
++\newcommand{\closeball}[2]{\overline{B_{#1}}\left(#2\right)}
++\newcommand{\closepar}[1]{\left[ #1 \right]}
++\newcommand{\openpar}[1]{\left] #1 \right[}
++\newcommand{\tuborgpar}[1]{\left\lbrace #1 \right\rbrace}
++\newcommand{\kau}{\text{\reflectbox{$\kappa$}}}
++\newcommand{\integral}[4]{\int_{#1}^{#2} #3 \, \mathrm{d}#4}
++\newcommand{\conj}[1]{\overline{#1}}
++\newcommand{\inpro}[1]{\left\langle #1 \right\rangle}
++\renewcommand{\vec}{\boldsymbol}
++\DeclareMathOperator*{\argmin}{arg\,min}
++\newcommand{\AR}[1]{\text{AR}\paren{#1}}
++\newcommand{\iid}{\overset{i.i.d.}{\sim}}
++\newcommand{\Var}{\text{Var}}
++\newcommand{\Poi}{\text{Poi}}
++\newcommand{\unif}{\text{unif}}
++\newcommand{\N}[2]{\text{N}\paren{#1,#2}}
++\newcommand{\ts}{\textsuperscript}
++\newcommand{\E}{\mathrm{E}}
++\newcommand{\mean}[1]{\E\karen{#1}}
++\newcommand{\autoko}[2]{\text{C}_{#1}\karen{#2}}
++\newcommand{\var}[1]{\Var\karen{#1}}
++\newcommand{\rom}[1]{\expandafter{\romannumeral #1\relax}}
++\DeclareMathOperator*{\argmax}{arg\,max}
++%% Text hyphen in math mode
++\mathchardef\mhyphen="2D
++
++% An ''in-text'' fraction with correct formatting
++\newcommand*\rfrac[2]{{}^{#1}\!/_{#2}}
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Programming related macros
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% C# macro
++\def\CS/{\settoheight{\dimen0}{C}C\kern-.05em \resizebox{!}{\dimen0}{\raisebox{\depth}{\#}}} 
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Table macros
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Correct formatted x for tables
++\newcommand{\tblX}[0]{{\fontfamily{cmss}\selectfont X}}
++% Ordentlig formattering af [...] i citater
++\newcommand{\quotecut}{}
++\def\quotecut/{\textnormal{[...]}}
++
++\newcommand{\emptystring}{\epsilon}
++\newcommand{\bnfnlor}{\\&\bnfor &}
++\def\bnfpo{\rightarrow}
+\ No newline at end of file
+diff --git a/Statusseminar/setup/preamble.tex b/Statusseminar/setup/preamble.tex
+new file mode 100644
+index 0000000..d08ff15
+--- /dev/null
++++ b/Statusseminar/setup/preamble.tex
+@@ -0,0 +1,428 @@
++%  A simple AAU report template.
++%  2015-05-08 v. 1.2.0
++%  Copyright 2010-2015 by Jesper Kjær Nielsen <jkn@es.aau.dk>
++%
++%  This is free software: you can redistribute it and/or modify
++%  it under the terms of the GNU General Public License as published by
++%  the Free Software Foundation, either version 3 of the License, or
++%  (at your option) any later version.
++%
++%  This is distributed in the hope that it will be useful,
++%  but WITHOUT ANY WARRANTY; without even the implied warranty of
++%  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++%  GNU General Public License for more details.
++%
++%  You can find the GNU General Public License at <http://www.gnu.org/licenses/>.
++%
++\documentclass[11pt,twoside,a4paper,openany]{report}
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Language, Encoding and Fonts
++% http://en.wikibooks.org/wiki/LaTeX/Internationalization
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Select encoding of your inputs. Depends on
++% your operating system and its default input
++% encoding. Typically, you should use
++%   Linux  : utf8 (most modern Linux distributions)
++%            latin1 
++%   Windows: ansinew
++%            latin1 (works in most cases)
++%   Mac    : applemac
++% Notice that you can manually change the input
++% encoding of your files by selecting "save as"
++% an select the desired input encoding. 
++\usepackage[utf8]{inputenc}
++% Make latex understand and use the typographic
++% rules of the language used in the document.
++\usepackage[english,danish]{babel}
++% Use the palatino font
++%\usepackage[sc]{mathpazo}
++%\linespread{1.05}         % Palatino needs more leading (space between lines)
++% Choose the font encoding
++
++\usepackage[T1]{fontenc}
++\usepackage{csquotes}
++\usepackage{parskip}
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Graphics and Tables
++% http://en.wikibooks.org/wiki/LaTeX/Importing_Graphics
++% http://en.wikibooks.org/wiki/LaTeX/Tables
++% http://en.wikibooks.org/wiki/LaTeX/Colors
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% load a colour package
++\usepackage[usenames,dvipsnames]{xcolor}
++\definecolor{aaublue}{RGB}{33,26,82}% dark blue
++\definecolor{aquablue}{RGB}{51,102,153}
++% The standard graphics inclusion package
++\usepackage{graphicx}
++% Set up how figure and table captions are displayed
++\usepackage{caption}
++\captionsetup{%
++  font=footnotesize,% set font size to footnotesize
++  labelfont=bf % bold label (e.g., Figure 3.2) font
++}
++\usepackage{wrapfig}
++% Make the standard latex tables look so much better
++\usepackage{array,booktabs,tabularx}
++\newcolumntype{Y}{>{\centering\arraybackslash}X}
++\usepackage{multirow}
++% Enable the use of frames around, e.g., theorems
++% The framed package is used in the example environment
++\usepackage{framed}
++% Include figures to keep paths clean
++\graphicspath{{figures/}}
++% Allow listings
++\usepackage{listings}
++% suppress warning of Excel-generated PDF's because of multiple page groups
++%\pdfsuppresswarningpagegroup=1
++% checkmark unicode (only necessary for pdftex)
++\DeclareUnicodeCharacter{2713}{\checkmark}
++% Allow subfigures
++\usepackage{subcaption}
++% Float for moving around figures more easily
++\usepackage{float}
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% TikZ & pgfplot
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++\usepackage{tikz}
++\usetikzlibrary{calc, 
++	shapes, 
++	arrows, 
++	positioning, 
++	intersections,
++	decorations.markings,
++	chains
++}
++% Flowchart styles
++\tikzstyle{decision} = [diamond, draw, fill=red!20, 
++text width=4.5em, text badly centered, node distance=3cm, inner sep=0pt]
++\tikzstyle{block} = [rectangle, draw, fill=blue!20, 
++text width=7em, text centered, rounded corners, minimum height=4em]
++\tikzstyle{block1} = [rectangle, draw, fill=blue!20,
++text width=7em, text centered, rounded corners, minimum height=4em, minimum width=3em]
++\tikzstyle{line} = [draw, -latex']
++\tikzstyle{cloud} = [draw, ellipse,fill=green!20, node distance=3cm,
++minimum height=4em, minimum width=7em]
++\tikzstyle{cloud1} = [draw, ellipse,fill=green!20, node distance=3cm,
++minimum height=2em]
++
++%Til sort magi med intersection bue
++\usepackage{tkz-euclide}
++\usetkzobj{all}
++
++% Plots
++\usepackage{pgfplots}
++\pgfplotsset{width=\textwidth,compat=1.5}
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% UML diagrams
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++%\usepackage{tikz-uml}
++%\input{setup/TikZ-UML-unicodefix.tex}
++%%Slimming oversized initial and final states
++%\tikzumlset{state initial width=4ex}
++%\tikzumlset{state final width=4ex}
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Mathematics
++% http://en.wikibooks.org/wiki/LaTeX/Mathematics
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Defines new environments such as equation,
++% align and split 
++\usepackage{amsmath}
++% Adds new math symbols
++\usepackage{amssymb}
++% Use theorems in your document
++% The ntheorem package is also used for the example environment
++% When using thmmarks, amsmath must be an option as well. Otherwise \eqref doesn't work anymore.
++\usepackage[framed,amsmath,thmmarks]{ntheorem}
++\usepackage[mathscr]{euscript}
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Page Layout
++% http://en.wikibooks.org/wiki/LaTeX/Page_Layout
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Change margins, papersize, etc of the document
++\usepackage[
++  inner=28mm,% left margin on an odd page
++  outer=41mm,% right margin on an odd page
++  headheight=14pt]{geometry}
++% Modify how \chapter, \section, etc. look
++% The titlesec package is very configureable
++\usepackage{titlesec}
++\titleformat{\chapter}[display]{\normalfont\huge\bfseries}{\chaptertitlename\ \thechapter}{20pt}{\Huge}
++\titleformat*{\section}{\normalfont\Large\bfseries}
++\titleformat*{\subsection}{\normalfont\large\bfseries}
++\titleformat*{\subsubsection}{\normalfont\normalsize\bfseries}
++%\titleformat*{\paragraph}{\normalfont\normalsize\bfseries}
++%\titleformat*{\subparagraph}{\normalfont\normalsize\bfseries}
++\usepackage{alphalph}
++
++% Clear empty pages between chapters
++\let\origdoublepage\cleardoublepage
++\newcommand{\clearemptydoublepage}{%
++  \clearpage
++  {\pagestyle{empty}\origdoublepage}%
++}
++\let\cleardoublepage\clearemptydoublepage
++
++% Change the headers and footers
++\usepackage{fancyhdr}
++\pagestyle{fancy}
++\fancyhf{} %delete everything
++\renewcommand{\headrulewidth}{0pt} %remove the horizontal line in the header
++\fancyhead[RE]{\small\nouppercase\leftmark} %even page - chapter title
++\fancyhead[LO]{\small\nouppercase\rightmark} %uneven page - section title
++\fancyhead[LE,RO]{\thepage} %page number on all pages
++% Do not stretch the content of a page. Instead,
++% insert white space at the bottom of the page
++\raggedbottom
++% Enable arithmetics with length. Useful when
++% typesetting the layout.
++\usepackage{calc}
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Bibliography
++% http://en.wikibooks.org/wiki/LaTeX/Bibliography_Management
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++\usepackage[
++  backend=biber,
++  bibencoding=utf8,
++  style=ieee,
++  sortcites=true,
++  sorting=nyt, % name year title
++  sortlocale=auto,
++  language=auto,
++%  date=edtf, 
++%  origdate=edtf, 
++%  eventdate=edtf,
++%  urldate=edtf,
++  ]{biblatex}
++\addbibresource{bib/mybib.bib}
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Misc
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Add bibliography and index to the table of
++% contents
++\usepackage[nottoc]{tocbibind}
++% Add the command \pageref{LastPage} which refers to the
++% page number of the last page
++\usepackage{lastpage}
++% Add todo notes in the margin of the document
++\usepackage[
++%  disable, %turn off todonotes
++  colorinlistoftodos, %enable a coloured square in the list of todos
++  textwidth=\marginparwidth, %set the width of the todonotes
++  textsize=scriptsize, %size of the text in the todonotes
++%  shadow=true, % enable shadow for good looking todonotes
++  ]{todonotes}
++\usepackage{appendix}
++\usepackage{mfirstuc}
++\usepackage{glossaries}
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Source formatting
++% http://texdoc.net/texmf-dist/doc/latex/listings/listings.pdf
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++\usepackage{listings}
++\usepackage{lstautodedent}
++
++% Pseudocode
++\usepackage{algorithm}
++\usepackage[noend]{algpseudocode}
++
++% Support for latin utf8 chars
++\lstset{literate=
++	{á}{{\'a}}1 {é}{{\'e}}1 {í}{{\'i}}1 {ó}{{\'o}}1 {ú}{{\'u}}1
++	{Á}{{\'A}}1 {É}{{\'E}}1 {Í}{{\'I}}1 {Ó}{{\'O}}1 {Ú}{{\'U}}1
++	{à}{{\`a}}1 {è}{{\`e}}1 {ì}{{\`i}}1 {ò}{{\`o}}1 {ù}{{\`u}}1
++	{À}{{\`A}}1 {È}{{\'E}}1 {Ì}{{\`I}}1 {Ò}{{\`O}}1 {Ù}{{\`U}}1
++	{ä}{{\"a}}1 {ë}{{\"e}}1 {ï}{{\"i}}1 {ö}{{\"o}}1 {ü}{{\"u}}1
++	{Ä}{{\"A}}1 {Ë}{{\"E}}1 {Ï}{{\"I}}1 {Ö}{{\"O}}1 {Ü}{{\"U}}1
++	{â}{{\^a}}1 {ê}{{\^e}}1 {î}{{\^i}}1 {ô}{{\^o}}1 {û}{{\^u}}1
++	{Â}{{\^A}}1 {Ê}{{\^E}}1 {Î}{{\^I}}1 {Ô}{{\^O}}1 {Û}{{\^U}}1
++	{œ}{{\oe}}1 {Œ}{{\OE}}1 {æ}{{\ae}}1 {Æ}{{\AE}}1 {ß}{{\ss}}1
++	{ű}{{\H{u}}}1 {Ű}{{\H{U}}}1 {ő}{{\H{o}}}1 {Ő}{{\H{O}}}1
++	{ç}{{\c c}}1 {Ç}{{\c C}}1 {ø}{{\o}}1 {å}{{\r a}}1 {Å}{{\r A}}1
++	{€}{{\euro}}1 {£}{{\pounds}}1 {«}{{\guillemotleft}}1
++	{»}{{\guillemotright}}1 {ñ}{{\~n}}1 {Ñ}{{\~N}}1 {¿}{{?`}}1
++}
++
++%% SQL-style
++\lstdefinestyle{SQL}{
++	language=SQL,
++	numbers=none,
++}
++
++% C# style
++\definecolor{bluekeywords}{rgb}{0,0,1}
++\definecolor{greencomments}{rgb}{0,0.5,0}
++\definecolor{redstrings}{rgb}{0.64,0.08,0.08}
++\definecolor{xmlcomments}{rgb}{0.5,0.5,0.5}
++\definecolor{types}{rgb}{0.17,0.57,0.68}
++\lstset{language=[Sharp]C,
++	captionpos=b,
++	numbers=left,
++	numberstyle=\tiny, 
++	frame=lines,
++	showspaces=false,
++	showtabs=false,
++	breaklines=true,
++	showstringspaces=false,
++	breakatwhitespace=true,
++	escapeinside={(*@}{@*)},
++	commentstyle=\color{greencomments},
++	morekeywords={partial, var, value, get, set},
++	keywordstyle=\color{bluekeywords},
++	stringstyle=\color{redstrings},
++	basicstyle=\ttfamily\small,
++	autodedent		= true,
++	tabsize = 4,
++}
++
++%% HTML-style
++\definecolor{OliveGreen}{RGB}{76,153,0}
++\lstdefinestyle{HTML}
++{
++	basicstyle      = \small\ttfamily,
++	morekeywords     = {footer}, 
++	keywordstyle    = \color{blue},
++	stringstyle     = \color{red},
++	identifierstyle = \color{black},
++	commentstyle    = \color{gray},
++	showstringspaces= false,
++	language        = HTML, 
++}
++
++% CSS driver for LaTeX lstlisting
++\lstdefinelanguage{CSS}{
++	morekeywords={accelerator,azimuth,background,background-attachment,
++		background-color,background-image,background-position,
++		background-position-x,background-position-y,background-repeat,
++		behavior,border,border-bottom,border-bottom-color,
++		border-bottom-style,border-bottom-width,border-collapse,
++		border-color,border-left,border-left-color,border-left-style,
++		border-left-width,border-right,border-right-color,
++		border-right-style,border-right-width,border-spacing,
++		border-style,border-top,border-top-color,border-top-style,
++		border-top-width,border-width,bottom,caption-side,clear,
++		clip,color,content,counter-increment,counter-reset,cue,
++		cue-after,cue-before,cursor,direction,display,elevation,
++		empty-cells,filter,float,font,font-family,font-size,
++		font-size-adjust,font-stretch,font-style,font-variant,
++		font-weight,height,ime-mode,include-source,
++		layer-background-color,layer-background-image,layout-flow,
++		layout-grid,layout-grid-char,layout-grid-char-spacing,
++		layout-grid-line,layout-grid-mode,layout-grid-type,left,
++		letter-spacing,line-break,line-height,list-style,
++		list-style-image,list-style-position,list-style-type,margin,
++		margin-bottom,margin-left,margin-right,margin-top,
++		marker-offset,marks,max-height,max-width,min-height,
++		min-width,-moz-binding,-moz-border-radius,
++		-moz-border-radius-topleft,-moz-border-radius-topright,
++		-moz-border-radius-bottomright,-moz-border-radius-bottomleft,
++		-moz-border-top-colors,-moz-border-right-colors,
++		-moz-border-bottom-colors,-moz-border-left-colors,-moz-opacity,
++		-moz-outline,-moz-outline-color,-moz-outline-style,
++		-moz-outline-width,-moz-user-focus,-moz-user-input,
++		-moz-user-modify,-moz-user-select,orphans,outline,
++		outline-color,outline-style,outline-width,overflow,
++		overflow-X,overflow-Y,padding,padding-bottom,padding-left,
++		padding-right,padding-top,page,page-break-after,
++		page-break-before,page-break-inside,pause,pause-after,
++		pause-before,pitch,pitch-range,play-during,position,quotes,
++		-replace,richness,right,ruby-align,ruby-overhang,
++		ruby-position,-set-link-source,size,speak,speak-header,
++		speak-numeral,speak-punctuation,speech-rate,stress,
++		scrollbar-arrow-color,scrollbar-base-color,
++		scrollbar-dark-shadow-color,scrollbar-face-color,
++		scrollbar-highlight-color,scrollbar-shadow-color,
++		scrollbar-3d-light-color,scrollbar-track-color,table-layout,
++		text-align,text-align-last,text-decoration,text-indent,
++		text-justify,text-overflow,text-shadow,text-transform,
++		text-autospace,text-kashida-space,text-underline-position,top,
++		unicode-bidi,-use-link-source,vertical-align,visibility,
++		voice-family,volume,white-space,widows,width,word-break,
++		word-spacing,word-wrap,writing-mode,z-index,zoom},
++	morestring=[s]{:}{;},
++	sensitive,
++	morecomment=[s]{/*}{*/}
++}
++
++\lstdefinestyle{CSS}
++{
++	basicstyle      = \small\ttfamily,
++	keywordstyle    = \color{red},
++	stringstyle     = \color{blue},
++	identifierstyle = \color{black},
++	commentstyle    = \color{gray},
++	showstringspaces= false,
++	language        = CSS
++}
++
++\let\origthelstnumber\thelstnumber
++\makeatletter
++\newcommand*\Suppressnumber{%
++	\lst@AddToHook{OnNewLine}{%
++		\let\thelstnumber\relax%
++		\advance\c@lstnumber-\@ne\relax%
++	}%
++}
++
++\newcommand*\Reactivatenumber[1]{%
++	\setcounter{lstnumber}{\numexpr#1-1\relax}
++	\lst@AddToHook{OnNewLine}{%
++		\let\thelstnumber\origthelstnumber%
++		\refstepcounter{lstnumber}%
++	}%
++}
++\makeatother
++
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Hyperlinks
++% http://en.wikibooks.org/wiki/LaTeX/Hyperlinks
++%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
++% Make footnotes able to crossref
++%https://tex.stackexchange.com/questions/95866/multiple-references-to-the-same-footnote-inside-a-table-environment
++\usepackage{scrextend}
++
++% Enable hyperlinks and insert info into the pdf
++% file. Hypperref should be loaded as one of the 
++% last packages
++\PassOptionsToPackage{hyphens}{url}
++\usepackage{hyperref}
++\hypersetup{%
++	%pdfpagelabels=true,%
++	plainpages=false,%
++	pdfauthor={Author(s)},%
++	pdftitle={Title},%
++	pdfsubject={Subject},%
++	bookmarksnumbered=true,%
++	colorlinks=false,%
++	citecolor=black,%
++	filecolor=black,%
++	linkcolor=black,% you should probably change this to black before printing
++	urlcolor=black,%
++	pdfstartview=FitH,%
++	hidelinks
++}
++
++%%%% Fix log spam because of pdf bookmark strings from hyperref %%%%
++%% See: https://tex.stackexchange.com/questions/193025/babel-hyperref-redefining-shorthand-several-times-per-page %%
++\makeatletter
++\declare@shorthand{danish}{"|}{}%
++\declare@shorthand{danish}{"~}{-}%
++\makeatother
++\floatname{algorithm}{Algoritme}
++
++\usepackage{longtable}
++\usepackage[normalem]{ulem}
++
++%%% Ting til grafer i TikZ
++\usetikzlibrary{arrows.meta}
++
++\newenvironment{vertices}{\begin{scope}[every node/.style={circle, thick, draw}]
++	}{\end{scope}}
++
++\newenvironment{edges}{\begin{scope}[>={Latex[black,scale=1.2]}]
++	}{\end{scope}}
++
++\usepackage[epsilon,tstt]{backnaur}	
+\ No newline at end of file

--- a/testEnviron/src/texthandling.php
+++ b/testEnviron/src/texthandling.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: waefwerf
+ * Date: 3/8/18
+ * Time: 11:21 AM
+ */
+
+function char_at($str, $pos) {
+    return mb_substr($str, $pos, 1);
+}
+
+function remove_todos($line)
+{
+    return remove_todos_old($line);
+}
+
+
+function remove_todos_old($line) {
+    $len = mb_strlen($line);
+    $pos = mb_strpos($line, "\\todo");
+    $stack = new SplStack();
+    $startparens = "([{";
+    $endparens = ")]}";
+    while ($pos < $len && $pos !== false  ) {
+        echo($line."\n");
+        echo(sprintf("pos == %s\n", $pos));
+        $startpos = $pos;
+        echo("Character at pos: ".char_at($line,$pos)."\n");
+        echo("Startpos = ".$startpos."\n");
+        /* Skip to first parenthesis */
+        while (mb_strpos($startparens, char_at($line, $pos)) === false) {
+            $pos++;
+            echo($pos." ");
+        }
+        /* Skip optional parameters */
+        if (char_at($line, $pos) == "[") {
+            $pos = mb_strpos($line, "]", $pos) + 1;
+//            while (char_at($line, $pos) !== "]") {
+//                $pos++;
+//            }
+//            echo(sprintf("charat pos %d == %s", $pos, char_at($line, $pos)));
+//            $pos++;
+            //$stack->pop();
+        }
+        //Skip to opening brace
+        while (char_at($line, $pos) !== "{") {
+            $pos++;
+        }
+        //$pos++;
+        $stack->push(char_at($line, $pos));
+        while (!$stack->isEmpty()) {
+            $pos++;
+            if (char_at($line, $pos) === "{") {
+                $stack->push(char_at($line, $pos));
+            }
+            elseif (char_at($line, $pos) === "}") {
+                $stack->pop();
+            }
+        }
+        echo(sprintf("Substring \"%s\" at pos %d to %d\n", $line, $startpos, $pos));
+        $line = str_replace(mb_substr($line, $startpos, $pos - $startpos + 1), "", $line);
+        echo(sprintf("After removal: %s\n", $line));
+        $pos = mb_strpos($line, "\\todo");
+    }
+    return $line;
+}
+function remove_todos_new($line)
+{
+    $len = strlen($line);
+    $pos = strpos($line, '\todo');
+    $stack = new SplStack();
+    while ($pos < $len && $pos !== false) {
+        echo("Todo found in line ".$line."\n");
+        $todoPos = $pos;
+        $bracePos = strpos($line, '{', $pos);
+        $pos = $bracePos;
+        $stack->push(char_at($line, $pos));
+        while (!$stack->isEmpty()) {
+            $pos++;
+            if (char_at($line, $pos) === '{') {
+                $stack->push('{');
+            }
+            if (char_at($line, $pos) === '}') {
+                $stack->pop();
+            }
+        }
+        $line = str_replace(mb_substr($line, $todoPos, $pos - $todoPos + 1), "", $line);
+        $pos = strpos($line, '\todo');
+        echo("Post removal: ".$line."\n");
+    }
+    return $line;
+}
+
+
+function manhunt($line) {
+    $line = str_replace("\t", "\\t",$line);
+    echo(sprintf("Filtered line: %s\n", $line));
+    $filtered_line = remove_todos($line);
+    if(str_split($filtered_line)[0] === '+'){
+        if(preg_match('/[\s+][mM]an[\W]/', $filtered_line)  === 1){
+            echo(sprintf("%s\n", $line));
+            return $line;
+        }
+        /*if(preg_match('/[\s+][Vv]i\W/', $line)  === 1){
+            $vi_lines[] = $line;
+            echo $line;
+        }*/
+    }
+    echo("No mans found\n");
+    return false;
+}
+

--- a/testEnviron/src/texthandling.php
+++ b/testEnviron/src/texthandling.php
@@ -14,35 +14,19 @@ function remove_todos($line) {
     $len = mb_strlen($line);
     $pos = mb_strpos($line, "\\todo");
     $stack = new SplStack();
-    $startparens = "([{";
-    $endparens = ")]}";
     while ($pos < $len && $pos !== false  ) {
         echo($line."\n");
         echo(sprintf("pos == %s\n", $pos));
         $startpos = $pos;
         echo("Character at pos: ".char_at($line,$pos)."\n");
         echo("Startpos = ".$startpos."\n");
-        /* Skip to first parenthesis */
-        while (mb_strpos($startparens, char_at($line, $pos)) === false) {
-            $pos++;
-            echo($pos." ");
-        }
-        /* Skip optional parameters */
-        if (char_at($line, $pos) == "[") {
-            $pos = mb_strpos($line, "]", $pos) + 1;
-//            while (char_at($line, $pos) !== "]") {
-//                $pos++;
-//            }
-//            echo(sprintf("charat pos %d == %s", $pos, char_at($line, $pos)));
-//            $pos++;
-            //$stack->pop();
-        }
         //Skip to opening brace
         while (char_at($line, $pos) !== "{") {
             $pos++;
         }
-        //$pos++;
+        //Use stack to track opened braces.
         $stack->push(char_at($line, $pos));
+        //Stack should be empty on closing brace.
         while (!$stack->isEmpty()) {
             $pos++;
             if (char_at($line, $pos) === "{") {
@@ -53,8 +37,10 @@ function remove_todos($line) {
             }
         }
         echo(sprintf("Substring \"%s\" at pos %d to %d\n", $line, $startpos, $pos));
+        //Remove contents
         $line = str_replace(mb_substr($line, $startpos, $pos - $startpos + 1), "", $line);
         echo(sprintf("After removal: %s\n", $line));
+        //Setup for next iteration
         $pos = mb_strpos($line, "\\todo");
     }
     return $line;

--- a/testEnviron/src/texthandling.php
+++ b/testEnviron/src/texthandling.php
@@ -10,13 +10,7 @@ function char_at($str, $pos) {
     return mb_substr($str, $pos, 1);
 }
 
-function remove_todos($line)
-{
-    return remove_todos_old($line);
-}
-
-
-function remove_todos_old($line) {
+function remove_todos($line) {
     $len = mb_strlen($line);
     $pos = mb_strpos($line, "\\todo");
     $stack = new SplStack();
@@ -65,34 +59,6 @@ function remove_todos_old($line) {
     }
     return $line;
 }
-function remove_todos_new($line)
-{
-    $len = strlen($line);
-    $pos = strpos($line, '\todo');
-    $stack = new SplStack();
-    while ($pos < $len && $pos !== false) {
-        echo("Todo found in line ".$line."\n");
-        $todoPos = $pos;
-        $bracePos = strpos($line, '{', $pos);
-        $pos = $bracePos;
-        $stack->push(char_at($line, $pos));
-        while (!$stack->isEmpty()) {
-            $pos++;
-            if (char_at($line, $pos) === '{') {
-                $stack->push('{');
-            }
-            if (char_at($line, $pos) === '}') {
-                $stack->pop();
-            }
-        }
-        $line = str_replace(mb_substr($line, $todoPos, $pos - $todoPos + 1), "", $line);
-        $pos = strpos($line, '\todo');
-        echo("Post removal: ".$line."\n");
-    }
-    return $line;
-}
-
-
 function manhunt($line) {
     $line = str_replace("\t", "\\t",$line);
     echo(sprintf("Filtered line: %s\n", $line));


### PR DESCRIPTION
Burde fikse et problem, der forårsagede seriøs logspam. Desuden er et simpelt testmiljø inkluderet, der indeholder den inderste løkke i manhunteren (som `manhunt()`) og indeholder nogle simple tests, der kan køres med PHPUnit (testet på version 7)